### PR TITLE
fix: prevent duplicate WWW sim assignments

### DIFF
--- a/server/wwwSimRoutes.js
+++ b/server/wwwSimRoutes.js
@@ -206,8 +206,12 @@ export default function setupWwwSimRoutes(app, sessions, ws) {
         if (!studentTemplates || typeof studentTemplates !== "object") {
             return res.status(400).json({ error: "invalid or missing student templates" });
         }
-        if (session.data.fragments && session.data.length > 0 &&
-            session.data.studentTemplates && Object.keys(session.data.studentTemplates).length > 0) {
+        if (
+            Array.isArray(session.data.fragments) &&
+            session.data.fragments.length > 0 &&
+            session.data.studentTemplates &&
+            Object.keys(session.data.studentTemplates).length > 0
+        ) {
             return res.status(409).json({ error: "hosting map and templates already assigned" });
         }
 


### PR DESCRIPTION
## Summary
- avoid incorrect `session.data.length` check and properly verify existing WWW simulation assignments

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a3c23d63d08329848af1e4b657aeab