### PR TITLE
feat: persist DNS table entries

### DIFF
--- a/client/src/components/user/WwwSim.jsx
+++ b/client/src/components/user/WwwSim.jsx
@@ -237,6 +237,7 @@ export default function WwwSim({ sessionData }) {
                                     template={templateRequests}
                                     initialDns={{}}
                                     onChange={(map) => console.log("DNS mapping:", map)}
+                                    sessionId={sessionId}
                                 />
 
                                 <StudentBrowserView template={templateRequests} sessionId={sessionId} />


### PR DESCRIPTION
## Summary
- persist DNS lookup table entries in browser localStorage
- key DNS table storage by session ID

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint --workspace client`


------
https://chatgpt.com/codex/tasks/task_e_68a3efab373c8329beb68ea363091f97