### PR TITLE
refactor: show instructions modal

### DIFF
--- a/client/src/components/ui/Modal.jsx
+++ b/client/src/components/ui/Modal.jsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+export default function Modal({ open, onClose, children }) {
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white max-w-3xl w-full mx-4 rounded shadow-lg max-h-[90vh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="p-2 flex justify-end">
+          <button
+            className="text-gray-500 hover:text-gray-700 text-xl leading-none"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            &times;
+          </button>
+        </div>
+        <div className="p-4">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/client/src/components/ui/WwwSimInstructions.jsx
+++ b/client/src/components/ui/WwwSimInstructions.jsx
@@ -1,9 +1,9 @@
 import React from "react";
 
 /**
- * InstructionsTab (post-join)
+ * Instructions content shown in a modal after joining.
  */
-export default function WwwSimInstructionsTab() {
+export default function WwwSimInstructions() {
   return (
     <div className="w-full lg:w-1/2 border border-gray-300 rounded mx-auto">
       <div className="bg-gray-200 px-3 py-1 text-xs font-semibold text-gray-700 border-b border-gray-300 rounded-t">

--- a/client/src/components/user/WwwSim.jsx
+++ b/client/src/components/user/WwwSim.jsx
@@ -3,7 +3,8 @@ import Button from "@src/components/ui/Button";
 import StudentHostDisplay from "@src/components/ui/StudentHostDisplay";
 import StudentBrowserView from "@src/components/ui/StudentBrowserView";
 import DNSLookupTable from "@src/components/ui/DNSLookupTable";
-import InstructionsTab from "@src/components/ui/WwwSimInstructionsTab";
+import Modal from "@src/components/ui/Modal";
+import Instructions from "@src/components/ui/WwwSimInstructions";
 
 export default function WwwSim({ sessionData }) {
     const sessionId = sessionData?.id;
@@ -20,7 +21,8 @@ export default function WwwSim({ sessionData }) {
     const [joined, setJoined] = useState(false);
     const [message, setMessage] = useState("");
     const [error, setError] = useState("");
-    const [selectedTab, setSelectedTab] = useState("instructions");
+    const [selectedTab, setSelectedTab] = useState("server");
+    const [showInstructions, setShowInstructions] = useState(false);
 
     const [hostAssignments, setHostAssignments] = useState([]);
     const [templateRequests, setTemplateRequests] = useState([]);
@@ -132,6 +134,7 @@ export default function WwwSim({ sessionData }) {
             }
             const data = await res.json();
             setJoined(true);
+            setShowInstructions(true);
             localStorage.setItem(storageKey, hostname);
 
             setMessage(data.message || "Joined! Waiting for instructor to start…");
@@ -163,6 +166,9 @@ export default function WwwSim({ sessionData }) {
 
     return (
         <div className="p-6 space-y-4">
+            <Modal open={showInstructions} onClose={() => setShowInstructions(false)}>
+                <Instructions />
+            </Modal>
             <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
                 <h1 className="text-2xl font-bold">
                     Web Simulation: HTTP & DNS Protocols
@@ -170,7 +176,14 @@ export default function WwwSim({ sessionData }) {
                 {joined && (
                     <p className="text-green-600 font-mono text-lg">{hostname}</p>
                 )}
-                <p className="text-gray-600">Join Code: <span className="font-mono">{sessionData.id}</span></p>
+                <div className="flex items-center gap-2">
+                    <p className="text-gray-600">Join Code: <span className="font-mono">{sessionData.id}</span></p>
+                    {joined && (
+                        <Button variant="outline" onClick={() => setShowInstructions(true)}>
+                            Instructions
+                        </Button>
+                    )}
+                </div>
 
             </div>
             {!joined && (
@@ -197,12 +210,6 @@ export default function WwwSim({ sessionData }) {
                 <>
                     <div className="flex gap-2 mt-4 border-b border-gray-300">
                         <button
-                            className={`px-3 py-1 text-sm font-medium ${selectedTab === "instructions" ? "border-b-2 border-blue-500 text-blue-600" : "text-gray-500"}`}
-                            onClick={() => setSelectedTab("instructions")}
-                        >
-                            Instructions
-                        </button>
-                        <button
                             className={`px-3 py-1 text-sm font-medium ${selectedTab === "server" ? "border-b-2 border-blue-500 text-blue-600" : "text-gray-500"}`}
                             onClick={() => setSelectedTab("server")}
                         >
@@ -217,11 +224,6 @@ export default function WwwSim({ sessionData }) {
                     </div>
 
                     <div className="mt-4">
-                        {selectedTab === "instructions" && (
-                            <div className="text-sm text-gray-800">
-                                <InstructionsTab />
-                            </div>
-                        )}
                         {selectedTab === "server" && (
                             <div className="text-sm text-gray-800">
                                 { hostAssignments && hostAssignments.length > 0 ? (


### PR DESCRIPTION
## Summary
- replace instructions tab with modal that auto-opens on join and is accessible from an "Instructions" button
- add a simple reusable Modal component
- simplify student view tabs to just Server and Browser

## Testing
- `npm test --workspace client` *(fails: Missing script: "test")*
- `npm run lint --workspace client`
- `npm test --workspace server` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a3f36938f48329822355c5e86eeb50