### PR TITLE
Persist DNS lookup table per session

### DIFF
--- a/client/src/components/user/WwwSim.jsx
+++ b/client/src/components/user/WwwSim.jsx
@@ -30,6 +30,8 @@ export default function WwwSim({ sessionData }) {
         templateRequestsRef.current = templateRequests;
     }, [templateRequests]);
 
+
+
     useEffect(() => {
         if (!joined || !sessionId) return;
 
@@ -235,8 +237,7 @@ export default function WwwSim({ sessionData }) {
                             <div className="text-sm text-gray-800">
                                 <DNSLookupTable
                                     template={templateRequests}
-                                    initialDns={{}}
-                                    onChange={(map) => console.log("DNS mapping:", map)}
+                                    sessionId={sessionId}
                                 />
 
                                 <StudentBrowserView template={templateRequests} sessionId={sessionId} />


### PR DESCRIPTION
## Summary
- Move DNS entry persistence into DNSLookupTable component keyed by session ID
- Simplify WwwSim by removing duplicate localStorage management

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a4003cb59c8329a89c21ffbf0b6b25