### PR TITLE
fix: persist DNS table across reloads

### DIFF
--- a/client/src/components/ui/DNSLookupTable.jsx
+++ b/client/src/components/ui/DNSLookupTable.jsx
@@ -22,13 +22,19 @@ export default function DNSLookupTable({ template, sessionId, onChange }) {
 
   // DNS mapping state
   const [dnsMap, setDnsMap] = useState({});
+  // Track whether we've loaded any existing data so that we don't
+  // immediately overwrite it in localStorage with an empty object
+  const [loaded, setLoaded] = useState(false);
 
   // Load from localStorage when hostnames or session changes
   useEffect(() => {
-    if (!storageKey) {
+    setLoaded(false);
+
+    if (!storageKey || hostnames.length === 0) {
       setDnsMap({});
       return;
     }
+
     try {
       const stored = localStorage.getItem(storageKey);
       const parsed = stored ? JSON.parse(stored) : {};
@@ -39,20 +45,26 @@ export default function DNSLookupTable({ template, sessionId, onChange }) {
       setDnsMap(next);
     } catch {
       const next = {};
-      hostnames.forEach(h => { next[h] = ""; });
+      hostnames.forEach(h => {
+        next[h] = "";
+      });
       setDnsMap(next);
+    } finally {
+      setLoaded(true);
     }
   }, [storageKey, hostnames]);
 
   // Persist to localStorage and notify parent
   useEffect(() => {
-    if (storageKey) {
+    if (storageKey && loaded) {
       try {
         localStorage.setItem(storageKey, JSON.stringify(dnsMap));
-      } catch {}
+      } catch {
+        // ignore write errors, e.g. storage quota exceeded
+      }
     }
     if (onChange) onChange(dnsMap);
-  }, [dnsMap, onChange, storageKey]);
+  }, [dnsMap, onChange, storageKey, loaded]);
 
   return (
     <div className="w-full lg:w-1/3 border border-gray-300 rounded mx-auto">


### PR DESCRIPTION
## Summary
- preserve DNS entries across page reloads by delaying localStorage writes until hostnames load
- guard storage updates with try/catch to handle quota errors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint --workspace client`

------
https://chatgpt.com/codex/tasks/task_e_68a4083db9e4832996399ca34b7d55b6