### PR TITLE
Update session lastActivity on keepalive

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -14,12 +14,14 @@ const app = express();
 app.use(express.json()); // Parse JSON request bodies
 
 const server = http.createServer(app);
-const ws = createWsRouter(server);
 
 // In-memory store shared by all session types
-const sessions = createSessionStore();
+const sessionTtl = Number(process.env.SESSION_TTL_MS) || 60 * 60 * 1000;
+const sessions = createSessionStore(sessionTtl);
 app.locals.sessions = sessions;
 setupSessionRoutes(app, sessions);
+
+const ws = createWsRouter(server, sessions);
 
 // Attach feature-specific route handlers
 setupRaffleRoutes(app, sessions, ws);

--- a/server/sessionStore.test.js
+++ b/server/sessionStore.test.js
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import http from 'node:http';
+import WebSocket from 'ws';
+import { createSessionStore, createSession } from './sessions.js';
+import { createWsRouter } from './wsRouter.js';
+
+const wait = ms => new Promise(res => setTimeout(res, ms));
+
+test('inactive sessions expire', async () => {
+    const sessions = createSessionStore(50);
+    const s = createSession(sessions);
+    await wait(60);
+    sessions.cleanup();
+    assert.strictEqual(sessions[s.id], undefined);
+});
+
+test('active sessions persist', async () => {
+    const sessions = createSessionStore(50);
+    const s = createSession(sessions);
+    await wait(40);
+    sessions[s.id]; // touch
+    await wait(40);
+    sessions.cleanup();
+    assert.ok(sessions[s.id]);
+    await wait(60);
+    sessions.cleanup();
+    assert.strictEqual(sessions[s.id], undefined);
+});
+
+test('keepalive refreshes session activity', async () => {
+    const sessions = createSessionStore(50);
+    const s = createSession(sessions);
+    const server = http.createServer();
+    const router = createWsRouter(server, sessions);
+    router.register('/ws', (socket, qp) => {
+        socket.sessionId = qp.get('sessionId');
+    });
+
+    await new Promise(resolve => server.listen(0, resolve));
+    const port = server.address().port;
+    const ws = new WebSocket(`ws://localhost:${port}/ws?sessionId=${s.id}`);
+    await new Promise(res => ws.once('open', res));
+
+    await wait(40);
+    await new Promise(res => { ws.once('pong', res); ws.ping(); });
+    await wait(20);
+    sessions.cleanup();
+    assert.ok(sessions[s.id]);
+
+    await wait(60);
+    sessions.cleanup();
+    assert.strictEqual(sessions[s.id], undefined);
+
+    ws.close();
+    await new Promise(res => server.close(res));
+});

--- a/server/wsRouter.js
+++ b/server/wsRouter.js
@@ -3,7 +3,7 @@ import { WebSocketServer } from "ws";
 /**
  * Creates a WebSocket router for handling connections in all activity modules.
  */
-export function createWsRouter(server) {
+export function createWsRouter(server, sessions) {
     const wss = new WebSocketServer({ noServer: true });
     const namespaces = new Map();
 
@@ -14,8 +14,22 @@ export function createWsRouter(server) {
             if (!onConn) return socket.destroy();
             wss.handleUpgrade(req, socket, head, (ws) => {
                 ws.isAlive = true;
-                ws.on("pong", () => (ws.isAlive = true));
+                const touch = () => {
+                    if (sessions && ws.sessionId) sessions[ws.sessionId];
+                };
+                ws.on("pong", () => {
+                    ws.isAlive = true;
+                    touch();
+                });
+                ws.on("ping", () => {
+                    ws.isAlive = true;
+                    touch();
+                });
                 onConn(ws, url.searchParams, wss);
+                if (sessions && ws.sessionId) sessions[ws.sessionId];
+                ws.on("message", () => {
+                    touch();
+                });
             });
         } catch { socket.destroy(); }
     });
@@ -23,7 +37,7 @@ export function createWsRouter(server) {
     setInterval(() => {
         for (const ws of wss.clients) {
             if (ws.isAlive === false) ws.terminate();
-            ws.isAlive = false; try { ws.ping(); } catch { }
+            ws.isAlive = false; try { ws.ping(ws.sessionId || ""); } catch { }
         }
     }, 30000).unref?.();
 


### PR DESCRIPTION
## Summary
- Refresh `lastActivity` on WebSocket ping/pong keepalive events
- Include session ID in server ping frames
- Add test verifying keepalive keeps session alive

## Testing
- `node --test server/sessionStore.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a603c7508883299717608bbcd07bb3