### PR TITLE
fix: update follow-redirects to patch auth header leak vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3939,9 +3939,9 @@
             "license": "ISC"
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.11",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
             "funding": [
                 {
                     "type": "individual",


### PR DESCRIPTION
## Summary

Updates `follow-redirects` past the vulnerable range (≤1.15.11) to address a moderate severity vulnerability where custom authentication headers were leaked to cross-domain redirect targets.

- **CVE**: [GHSA-r4q5-vmmm-2653](https://github.com/advisories/GHSA-r4q5-vmmm-2653)
- **Severity**: Moderate
- **Fix**: Bumped via `npm audit fix` — only `package-lock.json` changed

## Validation

```
npm audit → found 0 vulnerabilities
```