### PR TITLE
Update SyncDeck MobCode payload docs

### DIFF
--- a/skills/syncdeck/references/ACTIVITY_PAYLOADS.md
+++ b/skills/syncdeck/references/ACTIVITY_PAYLOADS.md
@@ -275,14 +275,15 @@ Field guidance:
 - `files` is an object map of relative virtual paths to UTF-8 text content
 - `activeFile` is optional and should match one of the `files` keys when provided
 - `runnerId` is optional; use `brython-terminal` to preselect the Python popup runner for Python-focused launches
-- paths should be safe relative paths such as `src/Main.java`; paths containing traversal segments such as `../` are rejected and will not load
+- paths are normalized as safe relative virtual paths such as `src/Main.java`; traversal segments such as `../`, empty paths, oversized paths, and reserved JavaScript object segments such as `__proto__`, `constructor`, or `prototype` are rejected and will not load
+- MobCode currently keeps up to 250 starter files, truncates individual file content at 1 MB, and stops accepting starter content once the total workspace seed reaches 4 MiB
 - omit `files` to start with an empty MobCode workspace
 
 ### Child embedded launch state
 
 MobCode reads `embeddedLaunch.selectedOptions.files` and `embeddedLaunch.selectedOptions.activeFile` only when the child session is first created without an existing MobCode file tree. After that, the live session state under `groups.default` is authoritative, so later reloads or reconnects do not overwrite instructor edits with the original starter payload.
 
-MobCode also reads `embeddedLaunch.selectedOptions.runnerId` on manager load to preselect the instructor's runner control. The current supported value is `brython-terminal`; unsupported values are ignored and the manager falls back to the default runner.
+MobCode also reads `embeddedLaunch.selectedOptions.runnerId` through the child session API so the instructor and students use the instructor-selected runner. The current supported value is `brython-terminal`; unsupported values are ignored and the activity falls back to the default runner. In the student view, available runner options collapse to the instructor-selected runner so students cannot switch to a different implementation.
 
 ## Raffle
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deck-authoring guidance with explicit path-safety normalization rules and workspace/file/content limits (up to 250 starter files, 1 MB per file, 4 MiB total).
  * Clarified when file settings are applied during deck launch.
  * Updated runner handling documentation to specify supported runners and constraints in student view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->