### PR TITLE
Restore Postboard student fetch/identity fix

### DIFF
--- a/activities/postboard/client/manager/PostboardManager.test.ts
+++ b/activities/postboard/client/manager/PostboardManager.test.ts
@@ -52,16 +52,16 @@ void test('reorderPostIds leaves the order unchanged for no-op or invalid drags'
   )
 })
 
-void test('getInstructorBoardCardClassName only reserves flag space for flagged posts', () => {
+void test('getInstructorBoardCardClassName always reserves space for the flag toggle control', () => {
+  // The flag toggle renders in every card corner regardless of flagged state,
+  // so the header must always reserve space for it to avoid overlapping the title.
   const unflaggedClassName = getInstructorBoardCardClassName(
     { id: 'post-1', status: 'approved', styleId: 'default' },
-    {},
   )
-  assert.ok(!unflaggedClassName.includes('postboard-card-with-flag'))
+  assert.ok(unflaggedClassName.includes('postboard-card-with-flag'))
 
   const flaggedClassName = getInstructorBoardCardClassName(
     { id: 'post-1', status: 'approved', styleId: 'default' },
-    { 'post-1': [{ id: 'flag-1', postId: 'post-1', createdAt: 1, flaggedBy: 'instructor' }] },
   )
   assert.ok(flaggedClassName.includes('postboard-card-with-flag'))
 })
@@ -69,7 +69,6 @@ void test('getInstructorBoardCardClassName only reserves flag space for flagged 
 void test('getInstructorBoardCardClassName includes faded and drag states', () => {
   const className = getInstructorBoardCardClassName(
     { id: 'post-1', status: 'deleted', styleId: 'default' },
-    {},
     { isDragging: true, isDragOver: true },
   )
 

--- a/activities/postboard/client/manager/PostboardManager.tsx
+++ b/activities/postboard/client/manager/PostboardManager.tsx
@@ -64,14 +64,14 @@ export function reorderPostIds(currentIds: string[], draggedId: string, targetId
 
 export function getInstructorBoardCardClassName(
   post: Pick<PostboardInstructorSnapshot['posts'][number], 'id' | 'status' | 'styleId'>,
-  flags: PostboardInstructorSnapshot['flags'],
   options: { isDragging?: boolean; isDragOver?: boolean } = {},
 ): string {
   const isFaded = post.status === 'rejected' || post.status === 'deleted'
-  const isFlagged = (flags[post.id]?.length ?? 0) > 0
   return [
     'postboard-card',
-    isFlagged ? 'postboard-card-with-flag' : '',
+    // The flag toggle control is always rendered in the card corner (flagged or not),
+    // so the header must always reserve space for it to avoid overlapping the title.
+    'postboard-card-with-flag',
     getNoteStyleClassName(post.styleId),
     isFaded ? 'postboard-card-rejected' : '',
     options.isDragging ? 'postboard-card-dragging' : '',
@@ -398,7 +398,7 @@ export default function PostboardManager(): React.JSX.Element {
                 return (
                 <article
                   key={post.id}
-                  className={getInstructorBoardCardClassName(post, snapshot?.flags ?? {}, {
+                  className={getInstructorBoardCardClassName(post, {
                     isDragging: draggedPostId === post.id,
                     isDragOver: dragOverPostId === post.id && draggedPostId !== post.id,
                   })}

--- a/activities/postboard/client/student/PostboardStudent.test.tsx
+++ b/activities/postboard/client/student/PostboardStudent.test.tsx
@@ -1,0 +1,129 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import * as React from 'react'
+import { JSDOM } from 'jsdom'
+import { buildSessionEntryParticipantStorageKey } from '@src/components/common/entryParticipantStorage'
+
+;(globalThis as { React?: typeof React }).React = React
+
+type TestingLibraryAct = (callback: () => void | Promise<void>) => void | Promise<void>
+
+function installDomEnvironment(url: string) {
+  const dom = new JSDOM('<!doctype html><html><body></body></html>', { url })
+
+  const previousWindow = globalThis.window
+  const previousDocument = globalThis.document
+  const previousNavigatorDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'navigator')
+  const previousHTMLElement = globalThis.HTMLElement
+  const previousNode = globalThis.Node
+
+  ;(globalThis as { window?: Window & typeof globalThis }).window = dom.window as unknown as Window & typeof globalThis
+  ;(globalThis as { document?: Document }).document = dom.window.document
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    writable: true,
+    value: dom.window.navigator,
+  })
+  globalThis.HTMLElement = dom.window.HTMLElement
+  globalThis.Node = dom.window.Node
+
+  return () => {
+    globalThis.document?.body?.replaceChildren()
+    dom.window.close()
+    ;(globalThis as { window?: Window & typeof globalThis }).window = previousWindow
+    ;(globalThis as { document?: Document }).document = previousDocument
+    globalThis.HTMLElement = previousHTMLElement
+    globalThis.Node = previousNode
+    if (previousNavigatorDescriptor) {
+      Object.defineProperty(globalThis, 'navigator', previousNavigatorDescriptor)
+    } else {
+      delete (globalThis as { navigator?: Navigator }).navigator
+    }
+  }
+}
+
+void test('submitting a note refreshes the board even while student identity resolution is still pending', { concurrency: false }, async () => {
+  const restoreDom = installDomEnvironment('https://bits.example/postboard/session-1')
+  const previousFetch = globalThis.fetch
+  let studentStateFetchCount = 0
+  const consumeControl: { resolve: ((response: Response) => void) | null } = { resolve: null }
+  const consumeResponse = new Promise<Response>((resolve) => {
+    consumeControl.resolve = resolve
+  })
+
+  // Seed a pending entry-participant "token" handoff so identity resolution stalls on a
+  // network round trip that this test controls and never resolves during the assertions below.
+  window.sessionStorage.setItem(
+    buildSessionEntryParticipantStorageKey('postboard', 'session-1'),
+    JSON.stringify({ kind: 'token', token: 'test-token' }),
+  )
+
+  globalThis.fetch = (async (input, init) => {
+    const url = String(input)
+
+    if (url.includes('/entry-participant/consume')) {
+      return consumeResponse
+    }
+
+    if (url.includes('/student-state')) {
+      studentStateFetchCount += 1
+      return new Response(JSON.stringify({
+        prompt: { text: 'Prompt' },
+        posts: [{ id: 'post-1', text: 'Hello there', styleId: 'default', status: 'pending', isOwnPost: true }],
+        reactionCounts: {},
+        viewerReactions: {},
+      }), { status: 200 })
+    }
+
+    if (url.endsWith('/posts')) {
+      return new Response(JSON.stringify({ ok: true }), { status: 200 })
+    }
+
+    throw new Error(`Unexpected fetch: ${url} ${String(init?.method)}`)
+  }) as typeof fetch
+
+  let cleanup: (() => void) | null = null
+  let unmount: (() => void) | null = null
+  let act: TestingLibraryAct | null = null
+
+  try {
+    const testingLibrary = await import('@testing-library/react')
+    const { fireEvent, render, waitFor } = testingLibrary
+    cleanup = testingLibrary.cleanup
+    act = testingLibrary.act
+    const { default: PostboardStudent } = await import('./PostboardStudent.js')
+
+    const rendered = render(
+      <PostboardStudent sessionData={{ sessionId: 'session-1', studentId: 'stu-1', studentName: 'Ada' }} />,
+    )
+    unmount = rendered.unmount
+
+    const textarea = rendered.container.querySelector('textarea')
+    assert.notEqual(textarea, null)
+    fireEvent.change(textarea as HTMLTextAreaElement, { target: { value: 'Hello there' } })
+    fireEvent.click(rendered.getByRole('button', { name: /submit note/i }))
+
+    // The identity-resolution consume request never settles, so if the post-submit
+    // refresh were still gated on identityResolved this would time out at zero fetches.
+    await waitFor(() => {
+      assert.equal(studentStateFetchCount, 1)
+    })
+    await waitFor(() => {
+      assert.ok(rendered.container.textContent?.includes('Hello there'))
+    })
+  } finally {
+    consumeControl.resolve?.(new Response(JSON.stringify({ values: {} }), { status: 200 }))
+    if (act) {
+      await act(async () => {
+        unmount?.()
+        cleanup?.()
+        await Promise.resolve()
+      })
+    } else {
+      unmount?.()
+      cleanup?.()
+    }
+    globalThis.fetch = previousFetch
+    restoreDom()
+  }
+})

--- a/activities/postboard/client/student/PostboardStudent.tsx
+++ b/activities/postboard/client/student/PostboardStudent.tsx
@@ -1,5 +1,8 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from 'react'
-import { readSessionParticipantContext } from '@src/components/common/sessionParticipantContext'
+import { useCallback, useEffect, useRef, useState, type FormEvent } from 'react'
+import {
+  persistSessionParticipantIdentity,
+  resolveInitialEntryParticipantIdentity,
+} from '@src/components/common/entryParticipantIdentityUtils'
 import Button from '@src/components/ui/Button'
 import NoteStyleSelect from '../../../shared/client/components/NoteStyleSelect.js'
 import ReactionSummary from '../../../shared/client/components/ReactionSummary.js'
@@ -28,24 +31,14 @@ interface StudentIdentity {
 
 const POLL_INTERVAL_MS = 2500
 
-function readStudentIdentity(sessionId: string | null, sessionData: PostboardStudentProps['sessionData']): StudentIdentity {
-  if (!sessionId || typeof window === 'undefined') {
-    return {
-      studentId: sessionData?.studentId ?? null,
-      studentName: sessionData?.studentName ?? null,
-    }
-  }
-
-  const context = readSessionParticipantContext(window.localStorage, sessionId)
-  return {
-    studentId: context?.studentId ?? sessionData?.studentId ?? null,
-    studentName: context?.studentName ?? sessionData?.studentName ?? null,
-  }
-}
-
 export default function PostboardStudent({ sessionData }: PostboardStudentProps): React.JSX.Element {
   const sessionId = sessionData?.sessionId ?? null
-  const identity = useMemo(() => readStudentIdentity(sessionId, sessionData), [sessionData, sessionId])
+  const isSoloSession = sessionId?.startsWith('solo-') === true
+  const [identity, setIdentity] = useState<StudentIdentity>(() => ({
+    studentId: sessionData?.studentId ?? null,
+    studentName: sessionData?.studentName ?? null,
+  }))
+  const [identityResolved, setIdentityResolved] = useState(false)
   const [snapshot, setSnapshot] = useState<PostboardStudentSnapshot | null>(null)
   const [draft, setDraft] = useState('')
   const [styleId, setStyleId] = useState(DEFAULT_NOTE_STYLE_ID)
@@ -54,8 +47,58 @@ export default function PostboardStudent({ sessionData }: PostboardStudentProps)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const fetchRequestIdRef = useRef(0)
 
+  useEffect(() => {
+    if (!sessionId || typeof window === 'undefined') {
+      setIdentity({
+        studentId: sessionData?.studentId ?? null,
+        studentName: sessionData?.studentName ?? null,
+      })
+      setIdentityResolved(true)
+      return undefined
+    }
+
+    let cancelled = false
+    setIdentityResolved(false)
+    void (async () => {
+      try {
+        const resolvedIdentity = await resolveInitialEntryParticipantIdentity({
+          activityName: 'postboard',
+          sessionId,
+          isSoloSession,
+          localStorage: window.localStorage,
+          sessionStorage: window.sessionStorage,
+          soloDisplayName: sessionData?.studentName ?? 'Solo Student',
+        })
+        if (cancelled) return
+
+        const studentName = resolvedIdentity.studentName || sessionData?.studentName || null
+        const studentId = resolvedIdentity.studentId ?? sessionData?.studentId ?? null
+        setIdentity({ studentName, studentId })
+        if (studentName || studentId) {
+          persistSessionParticipantIdentity(window.localStorage, sessionId, studentName ?? '', studentId)
+        }
+      } catch (identityError) {
+        console.error('[postboard] Failed to resolve student identity:', identityError)
+        if (!cancelled) {
+          setIdentity({
+            studentId: sessionData?.studentId ?? null,
+            studentName: sessionData?.studentName ?? null,
+          })
+        }
+      } finally {
+        if (!cancelled) {
+          setIdentityResolved(true)
+        }
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [isSoloSession, sessionData?.studentId, sessionData?.studentName, sessionId])
+
   const fetchState = useCallback(async () => {
-    if (!sessionId) return false
+    if (!sessionId || !identityResolved) return false
     const requestId = fetchRequestIdRef.current + 1
     fetchRequestIdRef.current = requestId
     const params = new URLSearchParams()
@@ -69,10 +112,10 @@ export default function PostboardStudent({ sessionData }: PostboardStudentProps)
     if (requestId !== fetchRequestIdRef.current) return false
     setSnapshot(nextSnapshot)
     return true
-  }, [identity.studentId, sessionId])
+  }, [identity.studentId, identityResolved, sessionId])
 
   useEffect(() => {
-    if (!sessionId) return undefined
+    if (!sessionId || !identityResolved) return undefined
     let cancelled = false
     const load = async () => {
       try {

--- a/activities/postboard/client/student/PostboardStudent.tsx
+++ b/activities/postboard/client/student/PostboardStudent.tsx
@@ -98,7 +98,7 @@ export default function PostboardStudent({ sessionData }: PostboardStudentProps)
   }, [isSoloSession, sessionData?.studentId, sessionData?.studentName, sessionId])
 
   const fetchState = useCallback(async () => {
-    if (!sessionId || !identityResolved) return false
+    if (!sessionId) return false
     const requestId = fetchRequestIdRef.current + 1
     fetchRequestIdRef.current = requestId
     const params = new URLSearchParams()
@@ -112,7 +112,7 @@ export default function PostboardStudent({ sessionData }: PostboardStudentProps)
     if (requestId !== fetchRequestIdRef.current) return false
     setSnapshot(nextSnapshot)
     return true
-  }, [identity.studentId, identityResolved, sessionId])
+  }, [identity.studentId, sessionId])
 
   useEffect(() => {
     if (!sessionId || !identityResolved) return undefined

--- a/activities/postboard/client/student/PostboardStudent.tsx
+++ b/activities/postboard/client/student/PostboardStudent.tsx
@@ -134,7 +134,7 @@ export default function PostboardStudent({ sessionData }: PostboardStudentProps)
       fetchRequestIdRef.current += 1
       window.clearInterval(interval)
     }
-  }, [fetchState, sessionId])
+  }, [fetchState, identityResolved, sessionId])
 
   const submitPost = async (text: string) => {
     if (!sessionId || !identity.studentId) {

--- a/client/src/components/common/entryParticipantIdentityUtils.test.ts
+++ b/client/src/components/common/entryParticipantIdentityUtils.test.ts
@@ -69,14 +69,14 @@ void test('persistSessionParticipantIdentity degrades gracefully when storage wr
   assert.match(warnings[2]?.message ?? '', /student id/i)
 })
 
-void test('resolveInitialEntryParticipantIdentity prefers stored live-session identity', async () => {
+void test('resolveInitialEntryParticipantIdentity prefers fresh live-session handoff over stale stored identity', async () => {
   const localStorage = createStorage()
   const sessionStorage = createStorage()
   persistSessionParticipantIdentity(localStorage, 'session-1', 'Grace', 'participant-1')
   persistEntryParticipantValues(
     sessionStorage,
     buildSessionEntryParticipantStorageKey('java-string-practice', 'session-1'),
-    { displayName: 'Ignored', participantId: 'participant-2' },
+    { displayName: 'Ada', participantId: 'participant-2' },
   )
 
   const identity = await resolveInitialEntryParticipantIdentity({
@@ -85,6 +85,29 @@ void test('resolveInitialEntryParticipantIdentity prefers stored live-session id
     isSoloSession: false,
     localStorage,
     sessionStorage,
+  })
+
+  assert.deepEqual(identity, {
+    studentName: 'Ada',
+    studentId: 'participant-2',
+    nameSubmitted: true,
+  })
+  assert.deepEqual(readSessionParticipantContext(localStorage, 'session-1'), {
+    studentName: 'Ada',
+    studentId: 'participant-2',
+  })
+})
+
+void test('resolveInitialEntryParticipantIdentity falls back to stored live-session identity without handoff', async () => {
+  const localStorage = createStorage()
+  persistSessionParticipantIdentity(localStorage, 'session-1', 'Grace', 'participant-1')
+
+  const identity = await resolveInitialEntryParticipantIdentity({
+    activityName: 'java-string-practice',
+    sessionId: 'session-1',
+    isSoloSession: false,
+    localStorage,
+    sessionStorage: createStorage(),
   })
 
   assert.deepEqual(identity, {

--- a/client/src/components/common/entryParticipantIdentityUtils.ts
+++ b/client/src/components/common/entryParticipantIdentityUtils.ts
@@ -129,13 +129,6 @@ export async function resolveInitialEntryParticipantIdentity(
     }
   }
 
-  if (localStorage) {
-    const storedIdentity = readStoredSessionParticipantIdentity(localStorage, sessionId)
-    if (storedIdentity) {
-      return storedIdentity
-    }
-  }
-
   if (preflightDisplayName || preflightParticipantId) {
     if (localStorage) {
       persistSessionParticipantContext(localStorage, sessionId, {
@@ -148,6 +141,13 @@ export async function resolveInitialEntryParticipantIdentity(
       studentName: preflightDisplayName ?? '',
       studentId: preflightParticipantId,
       nameSubmitted: true,
+    }
+  }
+
+  if (localStorage) {
+    const storedIdentity = readStoredSessionParticipantIdentity(localStorage, sessionId)
+    if (storedIdentity) {
+      return storedIdentity
     }
   }
 


### PR DESCRIPTION
## Summary
- Re-applies the Postboard student bug fixes from `postboard-fix` (PR #285) directly on top of current `main`, without pulling back in the rest of the activity report generation feature that PR #287 reverted.
- Fixes students being unable to post and instructor flag display, adds the missing `identityResolved` dependency, and lets `fetchState` refresh regardless of pending identity resolution.

Commits cherry-picked cleanly (no conflicts) from `postboard-fix`:
- `fix student unable to post and instructor flag display`
- `added the missing identityResolved to the second useEffect's dependency array`
- `Let fetchState refresh regardless of pending identity resolution`

## Test plan
- [x] `npm run test:activities:activity --activity=postboard` — 27/27 pass
- [x] `npm --workspace client run typecheck` — clean
- [x] `npm --workspace client run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)