### PR TITLE
Fix SyncDeck report layout and filter unsupported activities

### DIFF
--- a/activities/syncdeck/server/reportHtml.test.ts
+++ b/activities/syncdeck/server/reportHtml.test.ts
@@ -173,8 +173,29 @@ void test('buildSyncDeckSessionReportHtml stacks activity/student cards full-wid
 
 void test('buildSyncDeckSessionReportHtml counts only reportable activities in the hero and session overview metrics', () => {
   const html = buildSyncDeckSessionReportHtml(createManifest())
-  assert.match(html, /Embedded activities: 1</)
-  assert.match(html, /"id":"activity-count","label":"Embedded Activities","value":1/)
+  assert.match(html, /Reportable activities: 1</)
+  assert.match(html, /"id":"activity-count","label":"Reportable Activities","value":1/)
+})
+
+void test('buildSyncDeckSessionReportHtml falls back to the summary description when an unsupported activity payload.reason is not a string', () => {
+  const manifest = createManifest()
+  const videoSyncActivity = manifest.activities[1]
+  assert.ok(videoSyncActivity)
+  videoSyncActivity.report.payload = {
+    status: 'unsupported',
+    reason: { message: 'not a string' },
+  }
+
+  const html = buildSyncDeckSessionReportHtml(manifest)
+  const dom = new JSDOM(html, { runScripts: 'dangerously', url: 'https://activebits.local/' })
+  const { document } = dom.window
+  try {
+    const summaryBlockGrid = document.getElementById('summary-block-grid')
+    assert.doesNotMatch(summaryBlockGrid?.innerHTML ?? '', /\[object Object\]/)
+    assert.match(summaryBlockGrid?.innerHTML ?? '', /Structured reporting is not available for this activity yet\./)
+  } finally {
+    dom.window.close()
+  }
 })
 
 void test('buildSyncDeckSessionReportHtml hides unsupported activities from the By Activity view and consolidates them in the summary', () => {

--- a/activities/syncdeck/server/reportHtml.test.ts
+++ b/activities/syncdeck/server/reportHtml.test.ts
@@ -189,19 +189,43 @@ void test('buildSyncDeckSessionReportHtml hides unsupported activities from the 
   const html = buildSyncDeckSessionReportHtml(manifest)
   const dom = new JSDOM(html, { runScripts: 'dangerously', url: 'https://activebits.local/' })
   const { document } = dom.window
+  try {
+    const summaryBlockGrid = document.getElementById('summary-block-grid')
+    assert.match(summaryBlockGrid?.innerHTML ?? '', /Activities without full reporting/)
+    assert.match(summaryBlockGrid?.innerHTML ?? '', /Video Sync/)
+    assert.match(summaryBlockGrid?.innerHTML ?? '', /2 instances/)
 
-  const summaryBlockGrid = document.getElementById('summary-block-grid')
-  assert.match(summaryBlockGrid?.innerHTML ?? '', /Activities without full reporting/)
-  assert.match(summaryBlockGrid?.innerHTML ?? '', /Video Sync/)
-  assert.match(summaryBlockGrid?.innerHTML ?? '', /2 instances/)
+    const activitiesTab = document.querySelector('[data-view="activities"]')
+    assert.ok(activitiesTab instanceof dom.window.HTMLElement)
+    ;(activitiesTab as HTMLElement).click()
 
-  const activitiesTab = document.querySelector('[data-view="activities"]')
-  assert.ok(activitiesTab instanceof dom.window.HTMLElement)
-  ;(activitiesTab as HTMLElement).click()
+    const activityGrid = document.getElementById('activity-grid')
+    assert.match(activityGrid?.innerHTML ?? '', /Bridge Critique Round/)
+    assert.doesNotMatch(activityGrid?.innerHTML ?? '', /Video Sync Report Unsupported/)
+  } finally {
+    dom.window.close()
+  }
+})
 
-  const activityGrid = document.getElementById('activity-grid')
-  assert.match(activityGrid?.innerHTML ?? '', /Bridge Critique Round/)
-  assert.doesNotMatch(activityGrid?.innerHTML ?? '', /Video Sync Report Unsupported/)
+void test('buildSyncDeckSessionReportHtml shows a friendly empty state in By Activity when every activity is unsupported', () => {
+  const manifest = createManifest()
+  manifest.activities = manifest.activities.filter((activity) => activity.activityId === 'video-sync')
 
-  dom.window.close()
+  const html = buildSyncDeckSessionReportHtml(manifest)
+  const dom = new JSDOM(html, { runScripts: 'dangerously', url: 'https://activebits.local/' })
+  const { document } = dom.window
+  try {
+    const activitiesTab = document.querySelector('[data-view="activities"]')
+    assert.ok(activitiesTab instanceof dom.window.HTMLElement)
+    ;(activitiesTab as HTMLElement).click()
+
+    const activityGrid = document.getElementById('activity-grid')
+    assert.match(
+      activityGrid?.innerHTML ?? '',
+      /None of the embedded activities in this session have added structured reporting support yet\./,
+    )
+    assert.doesNotMatch(activityGrid?.innerHTML ?? '', /Video Sync Report Unsupported/)
+  } finally {
+    dom.window.close()
+  }
 })

--- a/activities/syncdeck/server/reportHtml.test.ts
+++ b/activities/syncdeck/server/reportHtml.test.ts
@@ -171,6 +171,12 @@ void test('buildSyncDeckSessionReportHtml stacks activity/student cards full-wid
   assert.match(html, /\.activity-grid, \.student-grid \{ grid-template-columns: 1fr; \}/)
 })
 
+void test('buildSyncDeckSessionReportHtml counts only reportable activities in the hero and session overview metrics', () => {
+  const html = buildSyncDeckSessionReportHtml(createManifest())
+  assert.match(html, /Embedded activities: 1</)
+  assert.match(html, /"id":"activity-count","label":"Embedded Activities","value":1/)
+})
+
 void test('buildSyncDeckSessionReportHtml hides unsupported activities from the By Activity view and consolidates them in the summary', () => {
   const manifest = createManifest()
   const videoSyncActivity = manifest.activities[1]

--- a/activities/syncdeck/server/reportHtml.test.ts
+++ b/activities/syncdeck/server/reportHtml.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { JSDOM } from 'jsdom'
 import {
   buildSyncDeckReportFilename,
   buildSyncDeckSessionReportHtml,
@@ -163,4 +164,44 @@ void test('buildSyncDeckSessionReportHtml renders aggregate summary, activity bl
   assert.match(html, /Avery - Bridge Design/)
   assert.doesNotMatch(html, /<script[^>]+src=/)
   assert.doesNotMatch(html, /<link[^>]+href=/)
+})
+
+void test('buildSyncDeckSessionReportHtml stacks activity/student cards full-width instead of a multi-column grid', () => {
+  const html = buildSyncDeckSessionReportHtml(createManifest())
+  assert.match(html, /\.activity-grid, \.student-grid \{ grid-template-columns: 1fr; \}/)
+})
+
+void test('buildSyncDeckSessionReportHtml hides unsupported activities from the By Activity view and consolidates them in the summary', () => {
+  const manifest = createManifest()
+  const videoSyncActivity = manifest.activities[1]
+  assert.ok(videoSyncActivity)
+  manifest.activities.push({
+    ...videoSyncActivity,
+    instanceKey: 'video-sync:9:0',
+    childSessionId: 'CHILD:syncdeck-42:ghi:video-sync',
+    report: {
+      ...videoSyncActivity.report,
+      instanceKey: 'video-sync:9:0',
+      childSessionId: 'CHILD:syncdeck-42:ghi:video-sync',
+    },
+  })
+
+  const html = buildSyncDeckSessionReportHtml(manifest)
+  const dom = new JSDOM(html, { runScripts: 'dangerously', url: 'https://activebits.local/' })
+  const { document } = dom.window
+
+  const summaryBlockGrid = document.getElementById('summary-block-grid')
+  assert.match(summaryBlockGrid?.innerHTML ?? '', /Activities without full reporting/)
+  assert.match(summaryBlockGrid?.innerHTML ?? '', /Video Sync/)
+  assert.match(summaryBlockGrid?.innerHTML ?? '', /2 instances/)
+
+  const activitiesTab = document.querySelector('[data-view="activities"]')
+  assert.ok(activitiesTab instanceof dom.window.HTMLElement)
+  ;(activitiesTab as HTMLElement).click()
+
+  const activityGrid = document.getElementById('activity-grid')
+  assert.match(activityGrid?.innerHTML ?? '', /Bridge Critique Round/)
+  assert.doesNotMatch(activityGrid?.innerHTML ?? '', /Video Sync Report Unsupported/)
+
+  dom.window.close()
 })

--- a/activities/syncdeck/server/reportHtml.ts
+++ b/activities/syncdeck/server/reportHtml.ts
@@ -45,7 +45,7 @@ function buildTopSummaryCards(
       id: 'session-overview',
       title: 'Session Overview',
       metrics: [
-        { id: 'activity-count', label: 'Embedded Activities', value: reportableActivityCount },
+        { id: 'activity-count', label: 'Reportable Activities', value: reportableActivityCount },
         { id: 'student-count', label: 'Students Represented', value: manifest.students.length },
       ],
     },
@@ -276,7 +276,7 @@ export function buildSyncDeckSessionReportHtml(manifest: SyncDeckSessionReportMa
       <h1>${escapeHtml(`Session ${manifest.parentSessionId}`)}</h1>
       <div class="meta">
         <span>Generated: ${escapeHtml(formatDate(manifest.generatedAt))}</span>
-        <span>Embedded activities: ${reportableActivityCount}</span>
+        <span>Reportable activities: ${reportableActivityCount}</span>
         <span>Students represented: ${manifest.students.length}</span>
       </div>
     </section>
@@ -400,9 +400,13 @@ export function buildSyncDeckSessionReportHtml(manifest: SyncDeckSessionReportMa
 
         const groups = new Map();
         activitiesWithoutReports.forEach((activity) => {
-          const reason = (activity.report && activity.report.payload && activity.report.payload.reason)
-            || (activity.report && Array.isArray(activity.report.summaryCards) && activity.report.summaryCards[0] && activity.report.summaryCards[0].description)
-            || 'This activity does not provide structured reporting for this session.';
+          const payloadReason = activity.report && activity.report.payload && activity.report.payload.reason;
+          const summaryDescription = activity.report && Array.isArray(activity.report.summaryCards) && activity.report.summaryCards[0] && activity.report.summaryCards[0].description;
+          const reason = typeof payloadReason === 'string' && payloadReason.length > 0
+            ? payloadReason
+            : typeof summaryDescription === 'string' && summaryDescription.length > 0
+              ? summaryDescription
+              : 'This activity does not provide structured reporting for this session.';
           const key = (activity.activityId || activity.activityName || 'activity') + '::' + reason;
           const existing = groups.get(key);
           if (existing) {

--- a/activities/syncdeck/server/reportHtml.ts
+++ b/activities/syncdeck/server/reportHtml.ts
@@ -157,7 +157,7 @@ export function buildSyncDeckSessionReportHtml(manifest: SyncDeckSessionReportMa
       gap: 14px;
     }
     .summary-grid { grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); margin-bottom: 18px; }
-    .activity-grid, .student-grid { grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); }
+    .activity-grid, .student-grid { grid-template-columns: 1fr; }
     .card, .activity-card, .student-card { padding: 16px; }
     .card h2, .activity-card h2, .student-card h2 { margin: 0 0 10px; font-size: 1.1rem; }
     .block-stack {
@@ -325,6 +325,12 @@ export function buildSyncDeckSessionReportHtml(manifest: SyncDeckSessionReportMa
       }[char]));
       const activities = Array.isArray(manifest.activities) ? manifest.activities : [];
       const students = Array.isArray(manifest.students) ? manifest.students : [];
+      const isUnsupportedReport = (activity) => {
+        const status = activity.report && activity.report.reportStatus;
+        return status === 'unsupported' || status === 'unavailable';
+      };
+      const reportableActivities = activities.filter((activity) => !isUnsupportedReport(activity));
+      const unsupportedActivities = activities.filter((activity) => isUnsupportedReport(activity));
 
       const topCards = ${toSafeJson(topSummaryCards)};
       const renderBlocks = (blocks) => {
@@ -375,6 +381,35 @@ export function buildSyncDeckSessionReportHtml(manifest: SyncDeckSessionReportMa
         }).join('');
       };
 
+      const renderUnsupportedSummaryCard = (activitiesWithoutReports) => {
+        if (activitiesWithoutReports.length === 0) {
+          return '';
+        }
+
+        const groups = new Map();
+        activitiesWithoutReports.forEach((activity) => {
+          const reason = (activity.report && activity.report.payload && activity.report.payload.reason)
+            || (activity.report && Array.isArray(activity.report.summaryCards) && activity.report.summaryCards[0] && activity.report.summaryCards[0].description)
+            || 'This activity does not provide structured reporting for this session.';
+          const key = (activity.activityId || activity.activityName || 'activity') + '::' + reason;
+          const existing = groups.get(key);
+          if (existing) {
+            existing.count += 1;
+          } else {
+            groups.set(key, { activityName: activity.activityName || activity.activityId, reason, count: 1 });
+          }
+        });
+
+        return '<article class="card">' +
+          '<h2>Activities without full reporting</h2>' +
+          '<ul class="section-list">' +
+            Array.from(groups.values()).map((group) =>
+              '<li><strong>' + escapeText(group.activityName) + '</strong> (' + group.count + (group.count === 1 ? ' instance' : ' instances') + '): ' + escapeText(group.reason) + '</li>'
+            ).join('') +
+          '</ul>' +
+        '</article>';
+      };
+
       summaryGrid.innerHTML = topCards.map((card) =>
         '<section class="card"><h2>' + escapeText(card.title) + '</h2><div class="metrics">' +
         (Array.isArray(card.metrics) ? card.metrics.map((metric) =>
@@ -382,7 +417,7 @@ export function buildSyncDeckSessionReportHtml(manifest: SyncDeckSessionReportMa
         ).join('') : '') +
         '</div></section>'
       ).join('');
-      summaryBlockGrid.innerHTML = activities.map((activity) => {
+      summaryBlockGrid.innerHTML = reportableActivities.map((activity) => {
         const scopeBlocks = activity.report && activity.report.scopeBlocks && activity.report.scopeBlocks['session-summary'];
         if (!Array.isArray(scopeBlocks) || scopeBlocks.length === 0) {
           return '';
@@ -393,11 +428,13 @@ export function buildSyncDeckSessionReportHtml(manifest: SyncDeckSessionReportMa
           '<h2>' + escapeText(activity.report && activity.report.title ? activity.report.title : activity.instanceKey) + '</h2>' +
           renderBlocks(scopeBlocks) +
         '</article>';
-      }).join('');
+      }).join('') + renderUnsupportedSummaryCard(unsupportedActivities);
 
       activityGrid.innerHTML = activities.length === 0
         ? '<div class="empty">No embedded activity reports were available for this session.</div>'
-        : activities.map((activity) => {
+        : reportableActivities.length === 0
+          ? '<div class="empty">None of the embedded activities in this session have added structured reporting support yet.</div>'
+          : reportableActivities.map((activity) => {
             const summaryCards = Array.isArray(activity.report && activity.report.summaryCards) ? activity.report.summaryCards : [];
             const studentsForActivity = Array.isArray(activity.report && activity.report.students) ? activity.report.students : [];
             const scopeBlocks = activity.report && activity.report.scopeBlocks && activity.report.scopeBlocks['activity-session'];
@@ -435,7 +472,7 @@ export function buildSyncDeckSessionReportHtml(manifest: SyncDeckSessionReportMa
 
       const renderStudent = (studentId) => {
         const student = students.find((entry) => entry.studentId === studentId) || null;
-        const relevantActivities = activities.filter((activity) =>
+        const relevantActivities = reportableActivities.filter((activity) =>
           Array.isArray(activity.report && activity.report.students)
           && activity.report.students.some((entry) => entry.studentId === studentId)
         );

--- a/activities/syncdeck/server/reportHtml.ts
+++ b/activities/syncdeck/server/reportHtml.ts
@@ -1,6 +1,7 @@
 import type {
   ActivityReportSummaryCard,
   SyncDeckSessionReportManifest,
+  SyncDeckSessionReportManifestActivity,
 } from '../../../types/activity.js'
 
 function escapeHtml(value: unknown): string {
@@ -30,13 +31,21 @@ function sanitizeFileLabel(value: string): string {
   return trimmed.length > 0 ? trimmed : 'syncdeck-report'
 }
 
-function buildTopSummaryCards(manifest: SyncDeckSessionReportManifest): ActivityReportSummaryCard[] {
+function isUnsupportedActivityReport(activity: SyncDeckSessionReportManifestActivity): boolean {
+  const status = activity.report.reportStatus
+  return status === 'unsupported' || status === 'unavailable'
+}
+
+function buildTopSummaryCards(
+  manifest: SyncDeckSessionReportManifest,
+  reportableActivityCount: number,
+): ActivityReportSummaryCard[] {
   return [
     {
       id: 'session-overview',
       title: 'Session Overview',
       metrics: [
-        { id: 'activity-count', label: 'Embedded Activities', value: manifest.activities.length },
+        { id: 'activity-count', label: 'Embedded Activities', value: reportableActivityCount },
         { id: 'student-count', label: 'Students Represented', value: manifest.students.length },
       ],
     },
@@ -49,7 +58,10 @@ export function buildSyncDeckReportFilename(manifest: SyncDeckSessionReportManif
 
 export function buildSyncDeckSessionReportHtml(manifest: SyncDeckSessionReportManifest): string {
   const reportJson = toSafeJson(manifest)
-  const topSummaryCards = buildTopSummaryCards(manifest)
+  const reportableActivityCount = manifest.activities.filter(
+    (activity) => !isUnsupportedActivityReport(activity),
+  ).length
+  const topSummaryCards = buildTopSummaryCards(manifest, reportableActivityCount)
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -264,7 +276,7 @@ export function buildSyncDeckSessionReportHtml(manifest: SyncDeckSessionReportMa
       <h1>${escapeHtml(`Session ${manifest.parentSessionId}`)}</h1>
       <div class="meta">
         <span>Generated: ${escapeHtml(formatDate(manifest.generatedAt))}</span>
-        <span>Embedded activities: ${manifest.activities.length}</span>
+        <span>Embedded activities: ${reportableActivityCount}</span>
         <span>Students represented: ${manifest.students.length}</span>
       </div>
     </section>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a summary card for activities without full reporting, including grouped reasons and instance counts.
  * Updated activity and student views to exclude unsupported or unavailable activities while retaining them in the session summary.
  * Added clearer empty-state messaging when structured activity reporting is unavailable.

* **Improvements**
  * Updated the report layout to use a full-width, single-column activity and student card view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->