### PR TITLE
fallback from youtube-nocookie to youtube on failure

### DIFF
--- a/.agent/knowledge/repo_discoveries.md
+++ b/.agent/knowledge/repo_discoveries.md
@@ -1802,3 +1802,11 @@ Use this log for durable findings that future contributors and agents should reu
 - Why it matters: Queueing updates per instructor socket preserves arrival order across asynchronous session reads and writes, preventing reveal or chalkboard state loss in both in-memory and Valkey deployments.
 - Evidence: `activities/syncdeck/server/routes.ts`; `activities/syncdeck/server/routes.test.ts`
 - Owner: Codex
+
+- Date: 2026-07-14
+- Area: activities (video-sync)
+- Discovery: `youtube-nocookie.com` embeds have no further fallback host when YouTube itself rejects a video (surfaced to the end user as YouTube's own in-iframe "configuration error", commonly numbered 153 — not an ActiveBits-generated code). This happens for videos that need a signed-in/cookied session to verify eligibility (e.g. age- or region-restricted), which the privacy-enhanced no-cookie domain cannot provide, and was reported by an instructor on iPad Safari where cookie/storage restrictions make it more likely. `resolveYoutubePlayerHostCandidates` now appends a final `youtube` (standard `https://www.youtube.com`) candidate after `youtube-nocookie` (and after the existing `youtube-education` → `youtube-nocookie` step), reusing the same onError/watchdog-timeout fallback mechanism already in place for the education host.
+- Why it matters: Previously an instructor whose video hit this YouTube-side rejection had no recovery path in the UI beyond picking a different video. The added third fallback candidate lets VideoSync recover automatically using the same mechanism that already existed for `youtube-education` failures.
+- Evidence: `activities/video-sync/shared/playerHosts.ts` (`PLAYER_HOST_FALLBACK_CHAIN`, `resolveYoutubePlayerHostCandidates`); `activities/video-sync/shared/playerHosts.test.ts`; `activities/video-sync/client/manager/VideoSyncManager.tsx` (`YOUTUBE_HOST_FALLBACK_TIMEOUT_MS`); `activities/video-sync/client/student/VideoSyncStudent.tsx` (`YOUTUBE_HOST_FALLBACK_TIMEOUT_MS`).
+- Follow-up action: The player's `onError` handlers still discard the numeric YouTube `event.data` error code (see the 2026-05-06 host-fallback entry above); if a future report needs to distinguish *which* YouTube error triggered a fallback, add telemetry that logs `event.data` before falling back.
+- Owner: Claude

--- a/activities/video-sync/client/manager/VideoSyncManager.tsx
+++ b/activities/video-sync/client/manager/VideoSyncManager.tsx
@@ -75,7 +75,7 @@ type AutoStartStatus = 'idle' | 'starting' | 'failed'
 
 const YOUTUBE_MANAGER_LOAD_ERROR = 'YouTube player failed to load. Try a different video URL.'
 const MISSING_INSTRUCTOR_CREDENTIALS_ERROR = 'Instructor credentials missing. Open this session from the dashboard or authenticated permalink.'
-const YOUTUBE_EDUCATION_FALLBACK_TIMEOUT_MS = 1_500
+const YOUTUBE_HOST_FALLBACK_TIMEOUT_MS = 1_500
 const MANAGER_PLAYING_DRIFT_TOLERANCE_SEC = 2
 const MANAGER_PLAYBACK_COMMAND_FLUSH_DELAY_MS = 120
 const MAX_MANAGER_API_ERROR_MESSAGE_LENGTH = 160
@@ -863,7 +863,7 @@ export default function VideoSyncManager() {
         clearPlayerReadyTimeout()
         playerReadyTimeoutId = window.setTimeout(() => {
           fallbackToNextHost(player)
-        }, YOUTUBE_EDUCATION_FALLBACK_TIMEOUT_MS)
+        }, YOUTUBE_HOST_FALLBACK_TIMEOUT_MS)
       }
 
       try {

--- a/activities/video-sync/client/student/VideoSyncStudent.tsx
+++ b/activities/video-sync/client/student/VideoSyncStudent.tsx
@@ -48,7 +48,7 @@ const STUDENT_PLAYING_DRIFT_TOLERANCE_SEC = 0.5
 const STUDENT_HARD_SEEK_DRIFT_SEC = 1.5
 const STUDENT_CATCH_UP_PLAYBACK_RATE = 1.25
 const STUDENT_SLOW_DOWN_PLAYBACK_RATE = 0.75
-const YOUTUBE_EDUCATION_FALLBACK_TIMEOUT_MS = 1_500
+const YOUTUBE_HOST_FALLBACK_TIMEOUT_MS = 1_500
 
 interface StudentPlaybackSyncAction {
   type: 'none' | 'rate' | 'seek'
@@ -584,7 +584,7 @@ export default function VideoSyncStudent({ sessionData }: VideoSyncStudentProps)
         clearPlayerReadyTimeout()
         playerReadyTimeoutId = window.setTimeout(() => {
           fallbackToNextHost(player)
-        }, YOUTUBE_EDUCATION_FALLBACK_TIMEOUT_MS)
+        }, YOUTUBE_HOST_FALLBACK_TIMEOUT_MS)
       }
 
       try {

--- a/activities/video-sync/shared/playerHosts.test.ts
+++ b/activities/video-sync/shared/playerHosts.test.ts
@@ -11,12 +11,14 @@ import {
 void test('formatVideoSyncPlayerHostLabel names status bar hosts', () => {
   assert.equal(formatVideoSyncPlayerHostLabel('youtube-education'), 'YouTube Education')
   assert.equal(formatVideoSyncPlayerHostLabel('youtube-nocookie'), 'YouTube no-cookie')
+  assert.equal(formatVideoSyncPlayerHostLabel('youtube'), 'YouTube')
   assert.equal(formatVideoSyncPlayerHostLabel(null), 'Not loaded')
 })
 
-void test('resolveYoutubePlayerHostUrl maps no-cookie and education hosts', () => {
+void test('resolveYoutubePlayerHostUrl maps no-cookie, education, and standard hosts', () => {
   assert.equal(resolveYoutubePlayerHostUrl('youtube-nocookie'), 'https://www.youtube-nocookie.com')
   assert.equal(resolveYoutubePlayerHostUrl('youtube-education'), 'https://www.youtubeeducation.com')
+  assert.equal(resolveYoutubePlayerHostUrl('youtube'), 'https://www.youtube.com')
 })
 
 void test('resolveYoutubeIframeApiSrc maps no-cookie and education hosts', () => {
@@ -24,7 +26,7 @@ void test('resolveYoutubeIframeApiSrc maps no-cookie and education hosts', () =>
   assert.equal(resolveYoutubeIframeApiSrc('youtube-education'), 'https://www.youtubeeducation.com/iframe_api')
 })
 
-void test('resolveYoutubePlayerHostCandidates falls back from education to no-cookie', () => {
+void test('resolveYoutubePlayerHostCandidates falls back from education to no-cookie to standard', () => {
   assert.deepEqual(resolveYoutubePlayerHostCandidates('youtube-education'), [
     {
       playerHost: 'youtube-education',
@@ -36,14 +38,34 @@ void test('resolveYoutubePlayerHostCandidates falls back from education to no-co
       hostUrl: 'https://www.youtube-nocookie.com',
       iframeApiSrc: 'https://www.youtube.com/iframe_api',
     },
+    {
+      playerHost: 'youtube',
+      hostUrl: 'https://www.youtube.com',
+      iframeApiSrc: 'https://www.youtube.com/iframe_api',
+    },
   ])
 })
 
-void test('resolveYoutubePlayerHostCandidates keeps no-cookie as a single host', () => {
+void test('resolveYoutubePlayerHostCandidates falls back from no-cookie to standard youtube.com', () => {
   assert.deepEqual(resolveYoutubePlayerHostCandidates('youtube-nocookie'), [
     {
       playerHost: 'youtube-nocookie',
       hostUrl: 'https://www.youtube-nocookie.com',
+      iframeApiSrc: 'https://www.youtube.com/iframe_api',
+    },
+    {
+      playerHost: 'youtube',
+      hostUrl: 'https://www.youtube.com',
+      iframeApiSrc: 'https://www.youtube.com/iframe_api',
+    },
+  ])
+})
+
+void test('resolveYoutubePlayerHostCandidates keeps standard youtube.com as a single host', () => {
+  assert.deepEqual(resolveYoutubePlayerHostCandidates('youtube'), [
+    {
+      playerHost: 'youtube',
+      hostUrl: 'https://www.youtube.com',
       iframeApiSrc: 'https://www.youtube.com/iframe_api',
     },
   ])

--- a/activities/video-sync/shared/playerHosts.ts
+++ b/activities/video-sync/shared/playerHosts.ts
@@ -1,10 +1,22 @@
-export type VideoSyncPlayerHost = 'youtube-nocookie' | 'youtube-education'
+export type VideoSyncPlayerHost = 'youtube-nocookie' | 'youtube-education' | 'youtube'
 
 export const DEFAULT_VIDEO_SYNC_PLAYER_HOST: VideoSyncPlayerHost = 'youtube-nocookie'
 export const YOUTUBE_NOCOOKIE_PLAYER_HOST_URL = 'https://www.youtube-nocookie.com'
 export const YOUTUBE_EDUCATION_PLAYER_HOST_URL = 'https://www.youtubeeducation.com'
+export const YOUTUBE_STANDARD_PLAYER_HOST_URL = 'https://www.youtube.com'
 export const YOUTUBE_IFRAME_API_SRC = 'https://www.youtube.com/iframe_api'
 export const YOUTUBE_EDUCATION_IFRAME_API_SRC = 'https://www.youtubeeducation.com/iframe_api'
+
+// A video that youtube-nocookie.com can't play without a signed-in/cookied
+// session (e.g. age- or region-restricted) surfaces as a YouTube-side
+// "configuration error" (commonly numbered 153) with no further recourse on
+// that domain. Falling back to the standard youtube.com host lets those
+// videos play instead of leaving instructors stuck on a dead embed.
+const PLAYER_HOST_FALLBACK_CHAIN: Record<VideoSyncPlayerHost, VideoSyncPlayerHost[]> = {
+  'youtube-education': ['youtube-education', 'youtube-nocookie', 'youtube'],
+  'youtube-nocookie': ['youtube-nocookie', 'youtube'],
+  youtube: ['youtube'],
+}
 
 export interface VideoSyncPlayerHostCandidate {
   playerHost: VideoSyncPlayerHost
@@ -13,7 +25,7 @@ export interface VideoSyncPlayerHostCandidate {
 }
 
 export function isVideoSyncPlayerHost(value: unknown): value is VideoSyncPlayerHost {
-  return value === 'youtube-nocookie' || value === 'youtube-education'
+  return value === 'youtube-nocookie' || value === 'youtube-education' || value === 'youtube'
 }
 
 export function normalizeVideoSyncPlayerHost(value: unknown): VideoSyncPlayerHost {
@@ -29,13 +41,23 @@ export function formatVideoSyncPlayerHostLabel(playerHost: VideoSyncPlayerHost |
     return 'YouTube no-cookie'
   }
 
+  if (playerHost === 'youtube') {
+    return 'YouTube'
+  }
+
   return 'Not loaded'
 }
 
 export function resolveYoutubePlayerHostUrl(playerHost: VideoSyncPlayerHost): string {
-  return playerHost === 'youtube-education'
-    ? YOUTUBE_EDUCATION_PLAYER_HOST_URL
-    : YOUTUBE_NOCOOKIE_PLAYER_HOST_URL
+  if (playerHost === 'youtube-education') {
+    return YOUTUBE_EDUCATION_PLAYER_HOST_URL
+  }
+
+  if (playerHost === 'youtube') {
+    return YOUTUBE_STANDARD_PLAYER_HOST_URL
+  }
+
+  return YOUTUBE_NOCOOKIE_PLAYER_HOST_URL
 }
 
 export function resolveYoutubeIframeApiSrc(playerHost: VideoSyncPlayerHost): string {
@@ -48,22 +70,11 @@ export function resolveYoutubePlayerHostCandidates(
   playerHost: VideoSyncPlayerHost,
 ): VideoSyncPlayerHostCandidate[] {
   const primary = normalizeVideoSyncPlayerHost(playerHost)
-  const primaryCandidate = {
-    playerHost: primary,
-    hostUrl: resolveYoutubePlayerHostUrl(primary),
-    iframeApiSrc: resolveYoutubeIframeApiSrc(primary),
-  }
+  const chain = PLAYER_HOST_FALLBACK_CHAIN[primary]
 
-  if (primary !== 'youtube-education') {
-    return [primaryCandidate]
-  }
-
-  return [
-    primaryCandidate,
-    {
-      playerHost: DEFAULT_VIDEO_SYNC_PLAYER_HOST,
-      hostUrl: resolveYoutubePlayerHostUrl(DEFAULT_VIDEO_SYNC_PLAYER_HOST),
-      iframeApiSrc: resolveYoutubeIframeApiSrc(DEFAULT_VIDEO_SYNC_PLAYER_HOST),
-    },
-  ]
+  return chain.map((host) => ({
+    playerHost: host,
+    hostUrl: resolveYoutubePlayerHostUrl(host),
+    iframeApiSrc: resolveYoutubeIframeApiSrc(host),
+  }))
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Video Sync playback reliability when YouTube’s privacy-enhanced or education player hosts fail.
  * Added automatic fallback to the standard YouTube player host after playback errors or timeouts.
  * Updated fallback handling to consistently support all available YouTube player hosts.

* **Tests**
  * Expanded coverage for YouTube host selection, URL resolution, labels, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->