### PR TITLE
fix(syncdeck): recover incomplete waiting room identity

### DIFF
--- a/.agent/knowledge/testing-patterns.md
+++ b/.agent/knowledge/testing-patterns.md
@@ -15,6 +15,15 @@ Capture reusable test setup patterns, common failure modes, and reliability guid
 
 ## Entries
 
+- Date: 2026-07-16
+- Scope: unit | SyncDeck utility UI
+- Pattern: When a JSDOM component test triggers a detached async UI handler, wrap the interaction in `await act(async () => { ... })`, allow its promise continuations to settle inside that boundary, and unmount in a final `act` boundary before restoring global DOM objects.
+- Why it helps: The `node:test` runner can otherwise observe a pending React state update after the test has restored `window`/`document`, producing an intermittent uncaught `TypeError` despite all assertions passing.
+- Example (file/path): `activities/syncdeck/client/util/SyncDeckLaunchPresentation.test.tsx`
+- Failure signal: CI reports asynchronous activity after the test ends, often with an error reading an event property, while the named assertion has already passed.
+- Follow-up action: Apply this only to tests that own a temporary JSDOM environment and invoke detached async handlers; do not add arbitrary delays when the interaction can be awaited through React's `act`.
+- Owner: Codex
+
 - Date: 2026-06-06
 - Scope: unit | integration
 - Pattern: For MobCode editor sync, test both sides of stale durable snapshot handling: editable manager clients should ignore remote durable `state-sync`/`file-tree-changed` echoes, and the server should merge durable `state-sync`/`file-tree-changed` payloads with the latest live websocket group only while an authenticated manager socket is connected. The merge keeps the requested file tree so creates/deletes/renames survive, while preserving live content for files that still exist in that requested tree.

--- a/activities/postboard/playwright/flow.spec.ts
+++ b/activities/postboard/playwright/flow.spec.ts
@@ -78,6 +78,7 @@ async function openPostboardStudent(
   page: Page,
   sessionId: string,
   student?: AcceptedStudent,
+  expectWaitingRoom = false,
 ): Promise<void> {
   await page.addInitScript(({ sessionId: targetSessionId, student: targetStudent }) => {
     if (targetStudent) {
@@ -91,6 +92,10 @@ async function openPostboardStudent(
     }
   }, { sessionId, student })
   await page.goto(`/${encodeURIComponent(sessionId)}`)
+  if (expectWaitingRoom) {
+    await expect(page.getByRole('button', { name: 'Join Session' })).toBeVisible()
+    return
+  }
   await expect(page.getByRole('heading', { name: 'Add a note' })).toBeVisible()
 }
 
@@ -155,7 +160,12 @@ test('student reactions require accepted identity and expose current reaction ac
   })
   await createInstructorPost(seedPage, session, 'A note from the instructor')
 
-  await openPostboardStudent(anonymousPage, session.id, { studentId: null, studentName: 'Waiting Student' })
+  await openPostboardStudent(
+    anonymousPage,
+    session.id,
+    { studentId: null, studentName: 'Waiting Student' },
+    true,
+  )
   await expect(anonymousPage.getByRole('button', { name: 'Choose reaction' })).toHaveCount(0)
 
   const grace = await acceptStudent(seedPage, session.id, 'Grace Hopper')

--- a/activities/syncdeck/client/util/SyncDeckLaunchPresentation.test.tsx
+++ b/activities/syncdeck/client/util/SyncDeckLaunchPresentation.test.tsx
@@ -480,7 +480,7 @@ void test('SyncDeckLaunchPresentation copies a generated permalink to the clipbo
   )
   const previousFetch = globalThis.fetch
   const writes: string[] = []
-  const { fireEvent, render, waitFor } = await import('@testing-library/react')
+  const { act, fireEvent, render, waitFor } = await import('@testing-library/react')
   const { MemoryRouter } = await import('react-router-dom')
   const { default: SyncDeckLaunchPresentation } = await import('./SyncDeckLaunchPresentation.js')
   let unmount: (() => void) | null = null
@@ -546,15 +546,20 @@ void test('SyncDeckLaunchPresentation copies a generated permalink to the clipbo
       assert.notEqual(rendered.queryByRole('button', { name: /^copy$/i }), null)
     })
 
-    fireEvent.click(rendered.getByRole('button', { name: /^copy$/i }))
+    await act(async () => {
+      fireEvent.click(rendered.getByRole('button', { name: /^copy$/i }))
+      await Promise.resolve()
+      await Promise.resolve()
+    })
 
     await waitFor(() => {
       assert.deepEqual(writes, [generatedUrl])
       assert.notEqual(rendered.queryByText(/copied link to clipboard/i), null)
     })
   } finally {
-    unmount?.()
-    await Promise.resolve()
+    await act(async () => {
+      unmount?.()
+    })
     ;(globalThis as { fetch?: typeof fetch }).fetch = previousFetch
     restoreDomEnvironment()
   }

--- a/client/src/components/common/SessionRouter.tsx
+++ b/client/src/components/common/SessionRouter.tsx
@@ -39,7 +39,7 @@ import {
   hasValidEntryParticipantHandoffStorageValue,
 } from './entryParticipantStorage'
 import { shouldAutoRedirectPersistentTeacherToManage, shouldRenderSessionJoinPreflight } from './sessionEntryRenderUtils'
-import { readSessionParticipantContext } from './sessionParticipantContext'
+import { hasCompleteSessionParticipantContext, readSessionParticipantContext } from './sessionParticipantContext'
 
 interface RouteParams {
   [key: string]: string | undefined
@@ -126,11 +126,13 @@ const SessionRouter = ({ onShellExpandChange }: SessionRouterProps = {}) => {
   const hasStoredSessionParticipantContext = (
     typeof window !== 'undefined'
     && sessionId != null
-  ) ? Boolean(readSessionParticipantContext(window.localStorage, sessionId)) : false
+  ) ? hasCompleteSessionParticipantContext(readSessionParticipantContext(window.localStorage, sessionId)) : false
   const hasStoredPersistentSessionParticipantContext = (
     typeof window !== 'undefined'
     && persistentSessionEntryStatus?.sessionId != null
-  ) ? Boolean(readSessionParticipantContext(window.localStorage, persistentSessionEntryStatus.sessionId)) : false
+  ) ? hasCompleteSessionParticipantContext(
+    readSessionParticipantContext(window.localStorage, persistentSessionEntryStatus.sessionId),
+  ) : false
   const hasStoredSessionEntryParticipantHandoff = (
     typeof window !== 'undefined'
     && sessionEntryStatus?.sessionId != null

--- a/client/src/components/common/sessionParticipantContext.test.ts
+++ b/client/src/components/common/sessionParticipantContext.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test'
 import type { EntryParticipantStorageLike } from './entryParticipantStorage'
 import {
   buildSessionParticipantContextStorageKey,
+  hasCompleteSessionParticipantContext,
   persistSessionParticipantContext,
   readSessionParticipantContext,
 } from './sessionParticipantContext'
@@ -53,6 +54,13 @@ void test('persistSessionParticipantContext merges later id-only updates with ex
     studentName: 'Ada',
     studentId: 'participant-1',
   })
+})
+
+void test('hasCompleteSessionParticipantContext requires both a name and participant id', () => {
+  assert.equal(hasCompleteSessionParticipantContext({ studentName: 'Ada', studentId: 'participant-1' }), true)
+  assert.equal(hasCompleteSessionParticipantContext({ studentName: 'Ada', studentId: null }), false)
+  assert.equal(hasCompleteSessionParticipantContext({ studentName: null, studentId: 'participant-1' }), false)
+  assert.equal(hasCompleteSessionParticipantContext(null), false)
 })
 
 void test('readSessionParticipantContext removes invalid stored payloads', () => {

--- a/client/src/components/common/sessionParticipantContext.ts
+++ b/client/src/components/common/sessionParticipantContext.ts
@@ -5,6 +5,10 @@ export interface SessionParticipantContext {
   studentId: string | null
 }
 
+export function hasCompleteSessionParticipantContext(context: SessionParticipantContext | null): boolean {
+  return context?.studentName != null && context.studentId != null
+}
+
 interface RawSessionParticipantContext {
   studentName?: unknown
   studentId?: unknown

--- a/client/src/components/common/sessionParticipantContext.ts
+++ b/client/src/components/common/sessionParticipantContext.ts
@@ -6,7 +6,7 @@ export interface SessionParticipantContext {
 }
 
 export function hasCompleteSessionParticipantContext(context: SessionParticipantContext | null): boolean {
-  return context?.studentName != null && context.studentId != null
+  return context?.studentName != null && context?.studentId != null
 }
 
 interface RawSessionParticipantContext {

--- a/client/src/components/common/waitingRoomHandoffUtils.test.ts
+++ b/client/src/components/common/waitingRoomHandoffUtils.test.ts
@@ -144,6 +144,31 @@ void test('persistWaitingRoomServerBackedHandoff falls back to local values when
   assert.equal(warnings[0], '[WaitingRoom] Failed to store entry participant on server, falling back to client handoff:')
 })
 
+void test('persistWaitingRoomServerBackedHandoff reports unavailable client handoff when storage is missing', async () => {
+  console.log('[TEST] exercising server handoff failure without browser storage')
+  const warnings: string[] = []
+
+  await persistWaitingRoomServerBackedHandoff({
+    storage: null,
+    storageKey: buildEntryParticipantStorageKey('syncdeck', 'session', 'session-4'),
+    values: { displayName: 'Grace' },
+    submitApiUrl: '/api/session/session-4/entry-participant',
+    fetchImpl: async () => ({
+      ok: false,
+      status: 500,
+      async json() {
+        return {}
+      },
+    }),
+    onWarn: (message) => warnings.push(message),
+  })
+
+  assert.equal(
+    warnings[0],
+    '[WaitingRoom] Failed to store entry participant on server; client handoff is unavailable because browser storage is unavailable:',
+  )
+})
+
 void test('persistWaitingRoomServerBackedHandoff falls back to local values when token is missing', async () => {
   const storage = createStorage()
   const storageKey = buildEntryParticipantStorageKey('java-string-practice', 'session', 'session-3')

--- a/client/src/components/common/waitingRoomHandoffUtils.test.ts
+++ b/client/src/components/common/waitingRoomHandoffUtils.test.ts
@@ -110,6 +110,36 @@ void test('persistWaitingRoomServerBackedHandoff persists the server-issued part
   })
 })
 
+void test('persistWaitingRoomServerBackedHandoff respects disabled participant context storage', async () => {
+  const storage = createStorage()
+  const storageKey = buildEntryParticipantStorageKey('syncdeck', 'session', 'session-1')
+
+  await persistWaitingRoomServerBackedHandoff({
+    storage,
+    participantContextStorage: null,
+    storageKey,
+    values: { displayName: 'Ada' },
+    submitApiUrl: '/api/session/session-1/entry-participant',
+    sessionParticipantContextSessionId: 'session-1',
+    fetchImpl: async () => ({
+      ok: true,
+      status: 200,
+      async json() {
+        return {
+          entryParticipantToken: 'token-123',
+          values: { displayName: 'Ada', participantId: 'participant-1' },
+        }
+      },
+    }),
+  })
+
+  assert.equal(readSessionParticipantContext(storage, 'session-1'), null)
+  assert.deepEqual(JSON.parse(String(storage.getItem(storageKey))), {
+    kind: 'token',
+    token: 'token-123',
+  })
+})
+
 void test('persistWaitingRoomServerBackedHandoff falls back to local values when server write fails', async () => {
   const storage = createStorage()
   const participantContextStorage = createStorage()

--- a/client/src/components/common/waitingRoomHandoffUtils.test.ts
+++ b/client/src/components/common/waitingRoomHandoffUtils.test.ts
@@ -83,6 +83,33 @@ void test('persistWaitingRoomServerBackedHandoff stores persistent hash with sol
   })
 })
 
+void test('persistWaitingRoomServerBackedHandoff persists the server-issued participant id without session storage', async () => {
+  const participantContextStorage = createStorage()
+
+  await persistWaitingRoomServerBackedHandoff({
+    storage: null,
+    participantContextStorage,
+    storageKey: buildEntryParticipantStorageKey('syncdeck', 'session', 'session-1'),
+    values: { displayName: 'Ada' },
+    submitApiUrl: '/api/session/session-1/entry-participant',
+    sessionParticipantContextSessionId: 'session-1',
+    fetchImpl: async () => ({
+      ok: true,
+      status: 200,
+      async json() {
+        return {
+          values: { displayName: 'Ada', participantId: 'participant-1' },
+        }
+      },
+    }),
+  })
+
+  assert.deepEqual(readSessionParticipantContext(participantContextStorage, 'session-1'), {
+    studentName: 'Ada',
+    studentId: 'participant-1',
+  })
+})
+
 void test('persistWaitingRoomServerBackedHandoff falls back to local values when server write fails', async () => {
   const storage = createStorage()
   const participantContextStorage = createStorage()

--- a/client/src/components/common/waitingRoomHandoffUtils.ts
+++ b/client/src/components/common/waitingRoomHandoffUtils.ts
@@ -89,9 +89,12 @@ export async function persistWaitingRoomServerBackedHandoff({
       ...(typeof persistentHash === 'string' ? { persistentHash } : {}),
     }, onWarn)
   } catch (error) {
-    onWarn('[WaitingRoom] Failed to store entry participant on server, falling back to client handoff:', error)
-    if (storage) {
-      persistEntryParticipantValues(storage, storageKey, values, onWarn)
+    if (!storage) {
+      onWarn('[WaitingRoom] Failed to store entry participant on server; client handoff is unavailable because browser storage is unavailable:', error)
+      return
     }
+
+    onWarn('[WaitingRoom] Failed to store entry participant on server, falling back to client handoff:', error)
+    persistEntryParticipantValues(storage, storageKey, values, onWarn)
   }
 }

--- a/client/src/components/common/waitingRoomHandoffUtils.ts
+++ b/client/src/components/common/waitingRoomHandoffUtils.ts
@@ -32,12 +32,14 @@ export async function persistWaitingRoomServerBackedHandoff({
   fetchImpl = typeof fetch === 'function' ? fetch.bind(globalThis) as EntryParticipantFetchLike : null,
   onWarn = console.warn,
 }: WaitingRoomHandoffPersistenceParams): Promise<void> {
-  if (!storage || !fetchImpl) {
+  if (!fetchImpl) {
     return
   }
 
-  if (sessionParticipantContextSessionId) {
-    persistSessionParticipantContext(participantContextStorage ?? storage, sessionParticipantContextSessionId, {
+  const resolvedParticipantContextStorage = participantContextStorage ?? storage
+
+  if (sessionParticipantContextSessionId && resolvedParticipantContextStorage) {
+    persistSessionParticipantContext(resolvedParticipantContextStorage, sessionParticipantContextSessionId, {
       studentName: getEntryParticipantDisplayName(values),
       studentId: getEntryParticipantParticipantId(values),
     }, onWarn)
@@ -60,22 +62,27 @@ export async function persistWaitingRoomServerBackedHandoff({
     }
 
     const payload = await response.json() as { entryParticipantToken?: unknown; values?: unknown }
-    const token = typeof payload.entryParticipantToken === 'string' ? payload.entryParticipantToken.trim() : ''
-    if (!token) {
-      throw new Error('Missing entry participant token')
-    }
-
     if (
       typeof sessionParticipantContextSessionId === 'string'
+      && resolvedParticipantContextStorage
       && typeof payload.values === 'object'
       && payload.values !== null
       && !Array.isArray(payload.values)
     ) {
       const responseValues = payload.values as EntryParticipantValueMap
-      persistSessionParticipantContext(participantContextStorage ?? storage, sessionParticipantContextSessionId, {
+      persistSessionParticipantContext(resolvedParticipantContextStorage, sessionParticipantContextSessionId, {
         studentName: getEntryParticipantDisplayName(responseValues),
         studentId: getEntryParticipantParticipantId(responseValues),
       }, onWarn)
+    }
+
+    if (!storage) {
+      return
+    }
+
+    const token = typeof payload.entryParticipantToken === 'string' ? payload.entryParticipantToken.trim() : ''
+    if (!token) {
+      throw new Error('Missing entry participant token')
     }
 
     persistEntryParticipantToken(storage, storageKey, token, {
@@ -83,6 +90,8 @@ export async function persistWaitingRoomServerBackedHandoff({
     }, onWarn)
   } catch (error) {
     onWarn('[WaitingRoom] Failed to store entry participant on server, falling back to client handoff:', error)
-    persistEntryParticipantValues(storage, storageKey, values, onWarn)
+    if (storage) {
+      persistEntryParticipantValues(storage, storageKey, values, onWarn)
+    }
   }
 }

--- a/client/src/components/common/waitingRoomHandoffUtils.ts
+++ b/client/src/components/common/waitingRoomHandoffUtils.ts
@@ -36,7 +36,7 @@ export async function persistWaitingRoomServerBackedHandoff({
     return
   }
 
-  const resolvedParticipantContextStorage = participantContextStorage ?? storage
+  const resolvedParticipantContextStorage = participantContextStorage
 
   if (sessionParticipantContextSessionId && resolvedParticipantContextStorage) {
     persistSessionParticipantContext(resolvedParticipantContextStorage, sessionParticipantContextSessionId, {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session validation so saved participant details are applied only when both name and ID are present.
  * Refined waiting-room handoff behavior when browser storage is unavailable, including clearer warnings and avoiding unsupported fallback flows.
  * Ensured server-provided participant IDs and participant context are persisted appropriately during server-backed handoffs.
  * Prevented token persistence and entry participant fallback persistence when storage isn’t available.

* **Tests**
  * Added tests for complete vs incomplete participant context.
  * Added tests for server-backed handoffs when storage is `null`.
  * Updated Playwright flow coverage to handle the waiting-room state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->