### PR TITLE
Add session-backed MobCode solo workspaces

### DIFF
--- a/.agent/knowledge/data-contracts.md
+++ b/.agent/knowledge/data-contracts.md
@@ -15,6 +15,15 @@ Document API and data-shape assumptions that must stay compatible over time.
 
 ## Contracts
 
+- Date: 2026-07-16
+- Surface: client routing | MobCode standalone solo entry
+- Contract: MobCode declares a permalink-capable standalone entry that uses `launchPersistentSoloEntry` to create a distinct server-backed workspace. It accepts optional `{ files, activeFile, runnerId }` selected options and returns a normal session route plus a scoped `mobcodeSoloToken` edit credential; the credential is not an instructor passcode.
+- Compatibility constraints: Managed `/manage/mobcode/:sessionId` keeps its passcode-gated server persistence and live websocket behavior. Non-solo student sessions remain read-only. Each solo launch creates its own session, preserving its workspace state for later activity-level reporting.
+- Validation rules: `POST /api/mobcode/create-solo` normalizes files using the existing path and byte limits. State writes accept either the instructor passcode or the matching solo edit token, and the session-read response never exposes either credential.
+- Evidence (schema/tests/path): `activities/mobcode/activity.config.ts`; `activities/mobcode/client/index.ts`; `activities/mobcode/client/student/MobCodeStudent.tsx`; `activities/mobcode/client/manager/MobCodeManager.tsx`; `activities/mobcode/server/routes.ts`; `activities/mobcode/server/routes.test.ts`.
+- Follow-up action: When SyncDeck’s parent report gains solo-child aggregation, persist an explicit parent-session and slide-instance association alongside this child session rather than inferring it from a browser overlay.
+- Owner: Codex
+
 - Date: 2026-07-14
 - Surface: REST | SyncDeck utility permalink builder
 - Contract: `POST /api/syncdeck/generate-url` now accepts an optional `entryPolicy` field (`instructor-required` | `solo-allowed` | `solo-only`, from `types/waitingRoom.ts`). This endpoint is called directly by the standalone `/util/syncdeck/permalink` utility page. SyncDeck's `activity.config.ts` also declares this same URL as `deepLinkGenerator.endpoint`, but that config is unused in practice: `manageDashboard.customPersistentLinkBuilder: true` makes `ManageDashboard` null out `deepLinkGenerator` for SyncDeck (`client/src/components/common/ManageDashboard.tsx` `submitPersistentLink`), so the Manage Dashboard permalink flow always posts to the generic `/api/persistent-session/create` instead. The client dropdown reuses `PERSISTENT_SESSION_ENTRY_POLICY_OPTIONS` from `client/src/components/common/persistentSessionEntryPolicyUtils.ts` via the `@src/...` alias.

--- a/activities/mobcode/activity.config.ts
+++ b/activities/mobcode/activity.config.ts
@@ -6,9 +6,9 @@ const mobCodeConfig: ActivityConfig = {
   description: 'Share a live multi-file code editor with students in real time',
   color: 'blue',
   standaloneEntry: {
-    enabled: false,
+    enabled: true,
     supportsDirectPath: false,
-    supportsPermalink: false,
+    supportsPermalink: true,
     showOnHome: false,
   },
   createSessionBootstrap: {

--- a/activities/mobcode/client/index.test.ts
+++ b/activities/mobcode/client/index.test.ts
@@ -23,5 +23,6 @@ void test('launchMobCodePersistentSoloEntry creates a server-backed workspace wi
     activeFile: 'starter.py',
     runnerId: 'brython-terminal',
   })
+  assert.equal(request.current?.init?.cache, 'no-store')
   assert.deepEqual(result, { navigateTo: '/solo-session?mobcodeSoloToken=opaque-token' })
 })

--- a/activities/mobcode/client/index.test.ts
+++ b/activities/mobcode/client/index.test.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { launchMobCodePersistentSoloEntry } from './index'
+
+void test('launchMobCodePersistentSoloEntry creates a server-backed workspace with the supplied starter files', async () => {
+  const request: { current: { input: RequestInfo | URL; init?: RequestInit } | null } = { current: null }
+  const result = await launchMobCodePersistentSoloEntry({
+    hash: '',
+    search: '',
+    selectedOptions: {
+      files: { 'starter.py': 'print("ready")' },
+      activeFile: 'starter.py',
+      runnerId: 'brython-terminal',
+    },
+  }, async (input, init) => {
+    request.current = { input, init }
+    return new Response(JSON.stringify({ id: 'solo-session', soloEditToken: 'opaque-token' }), { status: 200 })
+  })
+
+  assert.equal(request.current?.input, '/api/mobcode/create-solo')
+  assert.deepEqual(JSON.parse(String(request.current?.init?.body)), {
+    files: { 'starter.py': 'print("ready")' },
+    activeFile: 'starter.py',
+    runnerId: 'brython-terminal',
+  })
+  assert.deepEqual(result, { navigateTo: '/solo-session?mobcodeSoloToken=opaque-token' })
+})

--- a/activities/mobcode/client/index.test.ts
+++ b/activities/mobcode/client/index.test.ts
@@ -24,5 +24,5 @@ void test('launchMobCodePersistentSoloEntry creates a server-backed workspace wi
     runnerId: 'brython-terminal',
   })
   assert.equal(request.current?.init?.cache, 'no-store')
-  assert.deepEqual(result, { navigateTo: '/solo-session?mobcodeSoloToken=opaque-token' })
+  assert.deepEqual(result, { navigateTo: '/solo-session#mobcodeSoloToken=opaque-token' })
 })

--- a/activities/mobcode/client/index.ts
+++ b/activities/mobcode/client/index.ts
@@ -1,8 +1,31 @@
 import ManagerComponent from './manager/MobCodeManager'
 import StudentComponent from './student/MobCodeStudent'
+import type { ActivityPersistentSoloLaunchParams, ActivityPersistentSoloLaunchResult } from '../../../types/activity.js'
+
+export async function launchMobCodePersistentSoloEntry(
+  params: ActivityPersistentSoloLaunchParams,
+  fetchImpl: typeof fetch = fetch,
+): Promise<ActivityPersistentSoloLaunchResult> {
+  const response = await fetchImpl('/api/mobcode/create-solo', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      files: params.selectedOptions.files,
+      activeFile: params.selectedOptions.activeFile,
+      runnerId: params.selectedOptions.runnerId,
+    }),
+  })
+  if (!response.ok) throw new Error('Failed to create a MobCode solo session.')
+  const created = await response.json() as { id?: unknown; soloEditToken?: unknown }
+  if (typeof created.id !== 'string' || typeof created.soloEditToken !== 'string') {
+    throw new Error('MobCode solo session response was invalid.')
+  }
+  return { navigateTo: `/${encodeURIComponent(created.id)}?mobcodeSoloToken=${encodeURIComponent(created.soloEditToken)}` }
+}
 
 export default {
   ManagerComponent,
   StudentComponent,
   footerContent: null,
+  launchPersistentSoloEntry: launchMobCodePersistentSoloEntry,
 }

--- a/activities/mobcode/client/index.ts
+++ b/activities/mobcode/client/index.ts
@@ -21,7 +21,7 @@ export async function launchMobCodePersistentSoloEntry(
   if (typeof created.id !== 'string' || typeof created.soloEditToken !== 'string') {
     throw new Error('MobCode solo session response was invalid.')
   }
-  return { navigateTo: `/${encodeURIComponent(created.id)}?mobcodeSoloToken=${encodeURIComponent(created.soloEditToken)}` }
+  return { navigateTo: `/${encodeURIComponent(created.id)}#mobcodeSoloToken=${encodeURIComponent(created.soloEditToken)}` }
 }
 
 export default {

--- a/activities/mobcode/client/index.ts
+++ b/activities/mobcode/client/index.ts
@@ -8,6 +8,7 @@ export async function launchMobCodePersistentSoloEntry(
 ): Promise<ActivityPersistentSoloLaunchResult> {
   const response = await fetchImpl('/api/mobcode/create-solo', {
     method: 'POST',
+    cache: 'no-store',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       files: params.selectedOptions.files,

--- a/activities/mobcode/client/manager/MobCodeManager.tsx
+++ b/activities/mobcode/client/manager/MobCodeManager.tsx
@@ -14,6 +14,7 @@ import type {
 } from '../../shared/types'
 import { isMobCodeRunnerId } from '../../shared/types'
 import CodeEditor from '../components/CodeEditor'
+import EditorToolbar from '../components/EditorToolbar'
 import FileNameModal from '../components/FileNameModal'
 import FileControlsMenuContent from '../components/FileControlsMenuContent'
 import RunnerControls from '../components/RunnerControls'
@@ -108,8 +109,23 @@ export function resolveOpenMobCodeManagerAuthMessage(params: {
     : null
 }
 
-export default function MobCodeManager() {
-  const { sessionId } = useParams()
+interface MobCodeManagerProps {
+  /** Session and opaque edit credential used by a server-backed solo workspace. */
+  sessionIdOverride?: string
+  soloEditToken?: string
+}
+
+export function resolveMobCodeWorkspaceAccess(params: {
+  isSolo: boolean
+  instructorPasscode: string
+}): boolean {
+  return params.isSolo || params.instructorPasscode.length > 0
+}
+
+export default function MobCodeManager({ sessionIdOverride, soloEditToken }: MobCodeManagerProps = {}) {
+  const { sessionId: routeSessionId } = useParams()
+  const sessionId = sessionIdOverride ?? routeSessionId
+  const isSolo = typeof soloEditToken === 'string' && soloEditToken.length > 0
   const encodedSessionId = sessionId ? encodeURIComponent(sessionId) : ''
   const location = useLocation()
   const fallbackInstructorPasscode = useMemo(() => resolveMobCodeInstructorPasscode({
@@ -121,9 +137,9 @@ export default function MobCodeManager() {
     search: location.search,
   })
   const [instructorPasscode, setInstructorPasscode] = useState(fallbackInstructorPasscode)
-  const canEdit = instructorPasscode.length > 0
+  const canEdit = resolveMobCodeWorkspaceAccess({ isSolo, instructorPasscode })
   const instructorAccessBanner = resolveMobCodeManagerAccessBanner({
-    instructorPasscode,
+    instructorPasscode: isSolo ? 'solo' : instructorPasscode,
     isResolving: embeddedManagerPasscodeExchange.isResolving,
   })
   const [files, setFiles] = useState<Record<string, string>>({})
@@ -186,15 +202,15 @@ export default function MobCodeManager() {
   }, [encodedSessionId, replaceFilesState, sessionId])
 
   const buildWsUrl = useCallback(() => {
-    if (!sessionId) return null
+    if (isSolo || !sessionId) return null
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
     const params = new URLSearchParams({ sessionId, role: 'manager' })
     return `${protocol}//${window.location.host}/ws/mobcode?${params.toString()}`
-  }, [sessionId])
+  }, [isSolo, sessionId])
 
   const { connect, disconnect, socketRef } = useResilientWebSocket({
     buildUrl: buildWsUrl,
-    shouldReconnect: true,
+    shouldReconnect: !isSolo,
     onOpen: (_event, ws) => {
       const authMessage = createMobCodeManagerAuthMessage(sessionId, instructorPasscode)
       if (authMessage) {
@@ -213,6 +229,7 @@ export default function MobCodeManager() {
   })
 
   useEffect(() => {
+    if (isSolo) return
     const socket = socketRef.current
     const authMessage = resolveOpenMobCodeManagerAuthMessage({
       sessionId,
@@ -223,16 +240,21 @@ export default function MobCodeManager() {
       return
     }
     socket.send(authMessage)
-  }, [instructorPasscode, sessionId, socketRef])
+  }, [instructorPasscode, isSolo, sessionId, socketRef])
 
   const persistState = useCallback(
     async (payload: MobCodeStatePayload, messageType: DurableMobCodeMessageType = MOB_CODE_MESSAGE_TYPES.STATE_SYNC) => {
-      if (!sessionId || !instructorPasscode) return
+      const credential = isSolo ? soloEditToken : instructorPasscode
+      if (!sessionId || !credential) return
       try {
         const response = await fetch(`/api/mobcode/${encodedSessionId}/state`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ ...payload, instructorPasscode, messageType }),
+          body: JSON.stringify({
+            ...payload,
+            ...(isSolo ? { soloEditToken } : { instructorPasscode }),
+            messageType,
+          }),
         })
         if (!response.ok) {
           throw new Error(`MobCode state persist failed with status ${response.status}`)
@@ -241,15 +263,15 @@ export default function MobCodeManager() {
         console.error('Failed to persist MobCode state:', error)
       }
     },
-    [encodedSessionId, sessionId, instructorPasscode],
+    [encodedSessionId, instructorPasscode, isSolo, sessionId, soloEditToken],
   )
 
   const sendWsMessage = useCallback(
     (type: MobCodeMessageType, payload: unknown): boolean => {
-      if (!sessionId || !instructorPasscode) return false
+      if (isSolo || !sessionId || !instructorPasscode) return false
       return sendMobCodeWsMessage(socketRef.current, { type, sessionId, payload })
     },
-    [instructorPasscode, sessionId, socketRef],
+    [instructorPasscode, isSolo, sessionId, socketRef],
   )
 
   const flushPendingPresenceSync = useCallback(() => {
@@ -305,6 +327,7 @@ export default function MobCodeManager() {
 
   const scheduleContentSync = useCallback(
     (path: string, content: string, selections: MobCodeSelectionRange[]) => {
+      if (isSolo) return
       pendingContentUpdateRef.current = { path, content, selections }
 
       const syncPlan = createLiveContentSyncPlan(Date.now(), lastLiveSyncAtRef.current, LIVE_CONTENT_SYNC_INTERVAL_MS)
@@ -323,11 +346,12 @@ export default function MobCodeManager() {
 
       schedulePersistSync()
     },
-    [flushPendingContentSync, schedulePersistSync],
+    [flushPendingContentSync, isSolo, schedulePersistSync],
   )
 
   const schedulePresenceSync = useCallback(
     (path: string, selections: MobCodeSelectionRange[]) => {
+      if (isSolo) return
       pendingPresenceRef.current = { path, selections }
 
       const syncPlan = createLiveContentSyncPlan(Date.now(), lastPresenceSyncAtRef.current, LIVE_PRESENCE_SYNC_INTERVAL_MS)
@@ -344,7 +368,7 @@ export default function MobCodeManager() {
         }, syncPlan.delayMs)
       }
     },
-    [flushPendingPresenceSync],
+    [flushPendingPresenceSync, isSolo],
   )
 
   const clearPendingSync = useCallback(() => {
@@ -365,7 +389,7 @@ export default function MobCodeManager() {
   }, [])
 
   useEffect(() => {
-    if (!sessionId) return undefined
+    if (isSolo || !sessionId) return undefined
     connect()
     return () => {
       const hasPendingContent = pendingContentUpdateRef.current != null
@@ -395,6 +419,7 @@ export default function MobCodeManager() {
     }
   }, [
     sessionId,
+    isSolo,
     connect,
     disconnect,
     flushPendingContentSync,
@@ -503,40 +528,62 @@ export default function MobCodeManager() {
 
   return (
     <div className="mobcode-shell">
-      <SessionHeader
-        activityName="Mob Code"
-        sessionId={sessionId}
-        includeBottomMargin={false}
-        actionMenuLabel={canEdit ? 'Files' : undefined}
-        actionMenuRole={canEdit ? 'menu' : undefined}
-        actionMenuContent={canEdit ? (
-          <FileControlsMenuContent
-            files={files}
-            onUploadFiles={(uploadedFiles) => {
-              importFilesIntoWorkspace(uploadedFiles)
-            }}
-            onCreateFile={() => setModalMode('create-file')}
-            onCreateFolder={() => setModalMode('create-folder')}
-            onMessageChange={setFileImportMessage}
-          />
-        ) : undefined}
-        headerActions={(
-          <div className="mobcode-header-actions">
-            <SettingsMenu theme={theme} onThemeChange={handleThemeChange} label="Theme" />
-          </div>
-        )}
-        centerHeaderActions={(
-          <div className="mobcode-runner-actions">
-            <RunnerControls
+      {isSolo ? (
+        <EditorToolbar
+          files={files}
+          theme={theme}
+          centerControls={(
+            <div className="mobcode-runner-actions">
+              <RunnerControls
+                files={files}
+                runnerId={runnerId}
+                runners={MOB_CODE_RUNNERS}
+                onRunCode={handleRunCode}
+                onRunnerChange={setRunnerId}
+              />
+            </div>
+          )}
+          onThemeChange={handleThemeChange}
+          onUploadFiles={importFilesIntoWorkspace}
+          onCreateFile={() => setModalMode('create-file')}
+          onCreateFolder={() => setModalMode('create-folder')}
+        />
+      ) : (
+        <SessionHeader
+          activityName="Mob Code"
+          sessionId={sessionId}
+          includeBottomMargin={false}
+          actionMenuLabel={canEdit ? 'Files' : undefined}
+          actionMenuRole={canEdit ? 'menu' : undefined}
+          actionMenuContent={canEdit ? (
+            <FileControlsMenuContent
               files={files}
-              runnerId={runnerId}
-              runners={MOB_CODE_RUNNERS}
-              onRunCode={handleRunCode}
-              onRunnerChange={setRunnerId}
+              onUploadFiles={(uploadedFiles) => {
+                importFilesIntoWorkspace(uploadedFiles)
+              }}
+              onCreateFile={() => setModalMode('create-file')}
+              onCreateFolder={() => setModalMode('create-folder')}
+              onMessageChange={setFileImportMessage}
             />
-          </div>
-        )}
-      />
+          ) : undefined}
+          headerActions={(
+            <div className="mobcode-header-actions">
+              <SettingsMenu theme={theme} onThemeChange={handleThemeChange} label="Theme" />
+            </div>
+          )}
+          centerHeaderActions={(
+            <div className="mobcode-runner-actions">
+              <RunnerControls
+                files={files}
+                runnerId={runnerId}
+                runners={MOB_CODE_RUNNERS}
+                onRunCode={handleRunCode}
+                onRunnerChange={setRunnerId}
+              />
+            </div>
+          )}
+        />
+      )}
       {instructorAccessBanner === 'loading' && (
         <div
           className="border-b border-amber-200 bg-amber-50 px-4 py-2 text-sm text-amber-800"

--- a/activities/mobcode/client/manager/MobCodeManager.tsx
+++ b/activities/mobcode/client/manager/MobCodeManager.tsx
@@ -113,6 +113,7 @@ interface MobCodeManagerProps {
   /** Session and opaque edit credential used by a server-backed solo workspace. */
   sessionIdOverride?: string
   soloEditToken?: string
+  soloMode?: boolean
 }
 
 export function resolveMobCodeWorkspaceAccess(params: {
@@ -122,10 +123,10 @@ export function resolveMobCodeWorkspaceAccess(params: {
   return params.isSolo || params.instructorPasscode.length > 0
 }
 
-export default function MobCodeManager({ sessionIdOverride, soloEditToken }: MobCodeManagerProps = {}) {
+export default function MobCodeManager({ sessionIdOverride, soloEditToken, soloMode = false }: MobCodeManagerProps = {}) {
   const { sessionId: routeSessionId } = useParams()
   const sessionId = sessionIdOverride ?? routeSessionId
-  const isSolo = typeof soloEditToken === 'string' && soloEditToken.length > 0
+  const isSolo = soloMode || (typeof soloEditToken === 'string' && soloEditToken.length > 0)
   const encodedSessionId = sessionId ? encodeURIComponent(sessionId) : ''
   const location = useLocation()
   const fallbackInstructorPasscode = useMemo(() => resolveMobCodeInstructorPasscode({
@@ -245,14 +246,14 @@ export default function MobCodeManager({ sessionIdOverride, soloEditToken }: Mob
   const persistState = useCallback(
     async (payload: MobCodeStatePayload, messageType: DurableMobCodeMessageType = MOB_CODE_MESSAGE_TYPES.STATE_SYNC) => {
       const credential = isSolo ? soloEditToken : instructorPasscode
-      if (!sessionId || !credential) return
+      if (!sessionId || (!isSolo && !credential)) return
       try {
         const response = await fetch(`/api/mobcode/${encodedSessionId}/state`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             ...payload,
-            ...(isSolo ? { soloEditToken } : { instructorPasscode }),
+            ...(isSolo && soloEditToken ? { soloEditToken } : !isSolo ? { instructorPasscode } : {}),
             messageType,
           }),
         })

--- a/activities/mobcode/client/manager/MobCodeManager.tsx
+++ b/activities/mobcode/client/manager/MobCodeManager.tsx
@@ -327,21 +327,22 @@ export default function MobCodeManager({ sessionIdOverride, soloEditToken }: Mob
 
   const scheduleContentSync = useCallback(
     (path: string, content: string, selections: MobCodeSelectionRange[]) => {
-      if (isSolo) return
-      pendingContentUpdateRef.current = { path, content, selections }
+      if (!isSolo) {
+        pendingContentUpdateRef.current = { path, content, selections }
 
-      const syncPlan = createLiveContentSyncPlan(Date.now(), lastLiveSyncAtRef.current, LIVE_CONTENT_SYNC_INTERVAL_MS)
-      if (syncPlan.sendImmediately) {
-        if (wsDebounceRef.current) {
-          clearTimeout(wsDebounceRef.current)
-          wsDebounceRef.current = null
-        }
-        flushPendingContentSync()
-      } else if (wsDebounceRef.current == null) {
-        wsDebounceRef.current = setTimeout(() => {
-          wsDebounceRef.current = null
+        const syncPlan = createLiveContentSyncPlan(Date.now(), lastLiveSyncAtRef.current, LIVE_CONTENT_SYNC_INTERVAL_MS)
+        if (syncPlan.sendImmediately) {
+          if (wsDebounceRef.current) {
+            clearTimeout(wsDebounceRef.current)
+            wsDebounceRef.current = null
+          }
           flushPendingContentSync()
-        }, syncPlan.delayMs)
+        } else if (wsDebounceRef.current == null) {
+          wsDebounceRef.current = setTimeout(() => {
+            wsDebounceRef.current = null
+            flushPendingContentSync()
+          }, syncPlan.delayMs)
+        }
       }
 
       schedulePersistSync()
@@ -389,7 +390,19 @@ export default function MobCodeManager({ sessionIdOverride, soloEditToken }: Mob
   }, [])
 
   useEffect(() => {
-    if (isSolo || !sessionId) return undefined
+    if (!sessionId) return undefined
+    if (isSolo) {
+      return () => {
+        const hasPendingPersist = persistDebounceRef.current != null
+        if (persistDebounceRef.current) {
+          clearTimeout(persistDebounceRef.current)
+          persistDebounceRef.current = null
+        }
+        if (hasPendingPersist) {
+          flushPendingPersistSync()
+        }
+      }
+    }
     connect()
     return () => {
       const hasPendingContent = pendingContentUpdateRef.current != null

--- a/activities/mobcode/client/manager/passcodeUtils.test.ts
+++ b/activities/mobcode/client/manager/passcodeUtils.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import {
   createMobCodeManagerAuthMessage,
+  resolveMobCodeWorkspaceAccess,
   resolveMobCodeManagerAccessBanner,
   resolveOpenMobCodeManagerAuthMessage,
 } from './MobCodeManager.js'
@@ -31,6 +32,12 @@ void test('createMobCodeManagerAuthMessage only emits authentication for complet
       payload: { instructorPasscode: 'teacher-pass' },
     },
   )
+})
+
+void test('resolveMobCodeWorkspaceAccess grants local solo workspaces edit access without credentials', () => {
+  assert.equal(resolveMobCodeWorkspaceAccess({ isSolo: true, instructorPasscode: '' }), true)
+  assert.equal(resolveMobCodeWorkspaceAccess({ isSolo: false, instructorPasscode: '' }), false)
+  assert.equal(resolveMobCodeWorkspaceAccess({ isSolo: false, instructorPasscode: 'teacher-pass' }), true)
 })
 
 void test('resolveMobCodeManagerAccessBanner distinguishes token resolution from missing credentials', () => {

--- a/activities/mobcode/client/student/MobCodeStudent.test.ts
+++ b/activities/mobcode/client/student/MobCodeStudent.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test'
 import {
   applyStudentFileContentUpdate,
   getStudentRunnerOptions,
+  removeMobCodeSoloTokenFromHash,
   removeMobCodeSoloTokenFromSearch,
   resolveMobCodeStudentRoute,
   resolveStudentActiveFileChange,
@@ -23,7 +24,7 @@ void test('applyStudentFileContentUpdate ignores updates for missing paths', () 
 })
 
 void test('resolveMobCodeStudentRoute selects the token-authenticated solo manager route only when present', () => {
-  assert.deepEqual(resolveMobCodeStudentRoute('?mobcodeSoloToken=opaque-token'), {
+  assert.deepEqual(resolveMobCodeStudentRoute('', undefined, '#mobcodeSoloToken=opaque-token'), {
     mode: 'solo',
     soloEditToken: 'opaque-token',
   })
@@ -34,6 +35,7 @@ void test('resolveMobCodeStudentRoute selects the token-authenticated solo manag
     soloEditToken: 'history-token',
   })
   assert.equal(removeMobCodeSoloTokenFromSearch('?mobcodeSoloToken=opaque-token&view=solo'), '?view=solo')
+  assert.equal(removeMobCodeSoloTokenFromHash('#mobcodeSoloToken=opaque-token&view=solo'), '#view=solo')
 })
 
 void test('resolveStudentActiveFileChange ignores missing active-file updates', () => {

--- a/activities/mobcode/client/student/MobCodeStudent.test.ts
+++ b/activities/mobcode/client/student/MobCodeStudent.test.ts
@@ -29,6 +29,10 @@ void test('resolveMobCodeStudentRoute selects the token-authenticated solo manag
   })
   assert.deepEqual(resolveMobCodeStudentRoute('?other=value'), { mode: 'live' })
   assert.deepEqual(resolveMobCodeStudentRoute('?mobcodeSoloToken=%20%20'), { mode: 'live' })
+  assert.deepEqual(resolveMobCodeStudentRoute('', { mobcodeSoloToken: ' history-token ' }), {
+    mode: 'solo',
+    soloEditToken: 'history-token',
+  })
   assert.equal(removeMobCodeSoloTokenFromSearch('?mobcodeSoloToken=opaque-token&view=solo'), '?view=solo')
 })
 

--- a/activities/mobcode/client/student/MobCodeStudent.test.ts
+++ b/activities/mobcode/client/student/MobCodeStudent.test.ts
@@ -29,6 +29,7 @@ void test('resolveMobCodeStudentRoute selects the token-authenticated solo manag
     soloEditToken: 'opaque-token',
   })
   assert.deepEqual(resolveMobCodeStudentRoute('?other=value'), { mode: 'live' })
+  assert.deepEqual(resolveMobCodeStudentRoute('?mobcodeSoloToken=opaque-token'), { mode: 'live' })
   assert.deepEqual(resolveMobCodeStudentRoute('?mobcodeSoloToken=%20%20'), { mode: 'live' })
   assert.deepEqual(resolveMobCodeStudentRoute('', { mobcodeSoloToken: ' history-token ' }), {
     mode: 'solo',

--- a/activities/mobcode/client/student/MobCodeStudent.test.ts
+++ b/activities/mobcode/client/student/MobCodeStudent.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test'
 import {
   applyStudentFileContentUpdate,
   getStudentRunnerOptions,
+  removeMobCodeSoloTokenFromSearch,
   resolveMobCodeStudentRoute,
   resolveStudentActiveFileChange,
   sanitizeStudentPresenceUpdate,
@@ -27,6 +28,8 @@ void test('resolveMobCodeStudentRoute selects the token-authenticated solo manag
     soloEditToken: 'opaque-token',
   })
   assert.deepEqual(resolveMobCodeStudentRoute('?other=value'), { mode: 'live' })
+  assert.deepEqual(resolveMobCodeStudentRoute('?mobcodeSoloToken=%20%20'), { mode: 'live' })
+  assert.equal(removeMobCodeSoloTokenFromSearch('?mobcodeSoloToken=opaque-token&view=solo'), '?view=solo')
 })
 
 void test('resolveStudentActiveFileChange ignores missing active-file updates', () => {

--- a/activities/mobcode/client/student/MobCodeStudent.test.ts
+++ b/activities/mobcode/client/student/MobCodeStudent.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test'
 import {
   applyStudentFileContentUpdate,
   getStudentRunnerOptions,
+  resolveMobCodeStudentRoute,
   resolveStudentActiveFileChange,
   sanitizeStudentPresenceUpdate,
 } from './MobCodeStudent'
@@ -18,6 +19,14 @@ void test('applyStudentFileContentUpdate ignores updates for missing paths', () 
   assert.deepEqual(applyStudentFileContentUpdate(files, 'Main.java', 'updated'), {
     'Main.java': 'updated',
   })
+})
+
+void test('resolveMobCodeStudentRoute selects the token-authenticated solo manager route only when present', () => {
+  assert.deepEqual(resolveMobCodeStudentRoute('?mobcodeSoloToken=opaque-token'), {
+    mode: 'solo',
+    soloEditToken: 'opaque-token',
+  })
+  assert.deepEqual(resolveMobCodeStudentRoute('?other=value'), { mode: 'live' })
 })
 
 void test('resolveStudentActiveFileChange ignores missing active-file updates', () => {

--- a/activities/mobcode/client/student/MobCodeStudent.tsx
+++ b/activities/mobcode/client/student/MobCodeStudent.tsx
@@ -37,8 +37,14 @@ function readMobCodeSoloTokenFromHistoryState(locationState: unknown): string {
   return typeof token === 'string' ? token.trim() : ''
 }
 
-export function resolveMobCodeStudentRoute(search: string, locationState?: unknown): MobCodeStudentRoute {
-  const soloEditToken = new URLSearchParams(search).get('mobcodeSoloToken')?.trim()
+function readMobCodeSoloTokenFromUrl(search: string, hash: string): string {
+  return new URLSearchParams(search).get('mobcodeSoloToken')?.trim()
+    || new URLSearchParams(hash.startsWith('#') ? hash.slice(1) : hash).get('mobcodeSoloToken')?.trim()
+    || ''
+}
+
+export function resolveMobCodeStudentRoute(search: string, locationState?: unknown, hash = ''): MobCodeStudentRoute {
+  const soloEditToken = readMobCodeSoloTokenFromUrl(search, hash)
     || readMobCodeSoloTokenFromHistoryState(locationState)
   return soloEditToken ? { mode: 'solo', soloEditToken } : { mode: 'live' }
 }
@@ -48,6 +54,13 @@ export function removeMobCodeSoloTokenFromSearch(search: string): string {
   params.delete('mobcodeSoloToken')
   const remainingSearch = params.toString()
   return remainingSearch ? `?${remainingSearch}` : ''
+}
+
+export function removeMobCodeSoloTokenFromHash(hash: string): string {
+  const params = new URLSearchParams(hash.startsWith('#') ? hash.slice(1) : hash)
+  params.delete('mobcodeSoloToken')
+  const remainingHash = params.toString()
+  return remainingHash ? `#${remainingHash}` : ''
 }
 
 interface SessionResponse {
@@ -145,20 +158,24 @@ export function getStudentRunnerOptions(
 
 export default function MobCodeStudent({ sessionData }: MobCodeStudentProps) {
   const location = useLocation()
-  const [route] = useState(() => resolveMobCodeStudentRoute(location.search, location.state))
+  const [route] = useState(() => resolveMobCodeStudentRoute(location.search, location.state, location.hash))
 
   useEffect(() => {
     if (route.mode !== 'solo' || typeof window === 'undefined') return
     const nextSearch = removeMobCodeSoloTokenFromSearch(location.search)
+    const nextHash = removeMobCodeSoloTokenFromHash(location.hash)
     const currentState = window.history.state != null && typeof window.history.state === 'object'
       ? window.history.state as Record<string, unknown>
       : {}
+    const currentRouterState = currentState.usr != null && typeof currentState.usr === 'object'
+      ? currentState.usr as Record<string, unknown>
+      : {}
     window.history.replaceState(
-      { ...currentState, mobcodeSoloToken: route.soloEditToken },
+      { ...currentState, usr: { ...currentRouterState, mobcodeSoloToken: route.soloEditToken } },
       '',
-      `${window.location.pathname}${nextSearch}${window.location.hash}`,
+      `${window.location.pathname}${nextSearch}${nextHash}`,
     )
-  }, [location.search, route])
+  }, [location.hash, location.search, route])
 
   return route.mode === 'solo'
     ? <MobCodeManager sessionIdOverride={sessionData.sessionId} soloEditToken={route.soloEditToken} soloMode />

--- a/activities/mobcode/client/student/MobCodeStudent.tsx
+++ b/activities/mobcode/client/student/MobCodeStudent.tsx
@@ -27,6 +27,15 @@ interface MobCodeStudentProps {
   }
 }
 
+export type MobCodeStudentRoute =
+  | { mode: 'solo'; soloEditToken: string }
+  | { mode: 'live' }
+
+export function resolveMobCodeStudentRoute(search: string): MobCodeStudentRoute {
+  const soloEditToken = new URLSearchParams(search).get('mobcodeSoloToken')
+  return soloEditToken ? { mode: 'solo', soloEditToken } : { mode: 'live' }
+}
+
 interface SessionResponse {
   data?: {
     runnerId?: unknown
@@ -121,10 +130,10 @@ export function getStudentRunnerOptions(
 
 export default function MobCodeStudent({ sessionData }: MobCodeStudentProps) {
   const location = useLocation()
-  const soloEditToken = new URLSearchParams(location.search).get('mobcodeSoloToken')
+  const route = resolveMobCodeStudentRoute(location.search)
 
-  return soloEditToken
-    ? <MobCodeManager sessionIdOverride={sessionData.sessionId} soloEditToken={soloEditToken} />
+  return route.mode === 'solo'
+    ? <MobCodeManager sessionIdOverride={sessionData.sessionId} soloEditToken={route.soloEditToken} />
     : <MobCodeLiveStudent sessionData={sessionData} />
 }
 

--- a/activities/mobcode/client/student/MobCodeStudent.tsx
+++ b/activities/mobcode/client/student/MobCodeStudent.tsx
@@ -37,14 +37,13 @@ function readMobCodeSoloTokenFromHistoryState(locationState: unknown): string {
   return typeof token === 'string' ? token.trim() : ''
 }
 
-function readMobCodeSoloTokenFromUrl(search: string, hash: string): string {
-  return new URLSearchParams(search).get('mobcodeSoloToken')?.trim()
-    || new URLSearchParams(hash.startsWith('#') ? hash.slice(1) : hash).get('mobcodeSoloToken')?.trim()
+function readMobCodeSoloTokenFromUrl(hash: string): string {
+  return new URLSearchParams(hash.startsWith('#') ? hash.slice(1) : hash).get('mobcodeSoloToken')?.trim()
     || ''
 }
 
-export function resolveMobCodeStudentRoute(search: string, locationState?: unknown, hash = ''): MobCodeStudentRoute {
-  const soloEditToken = readMobCodeSoloTokenFromUrl(search, hash)
+export function resolveMobCodeStudentRoute(_search: string, locationState?: unknown, hash = ''): MobCodeStudentRoute {
+  const soloEditToken = readMobCodeSoloTokenFromUrl(hash)
     || readMobCodeSoloTokenFromHistoryState(locationState)
   return soloEditToken ? { mode: 'solo', soloEditToken } : { mode: 'live' }
 }

--- a/activities/mobcode/client/student/MobCodeStudent.tsx
+++ b/activities/mobcode/client/student/MobCodeStudent.tsx
@@ -46,6 +46,7 @@ export function removeMobCodeSoloTokenFromSearch(search: string): string {
 interface SessionResponse {
   data?: {
     runnerId?: unknown
+    canEditSolo?: unknown
     groups?: {
       default?: {
         files?: unknown
@@ -146,7 +147,7 @@ export default function MobCodeStudent({ sessionData }: MobCodeStudentProps) {
   }, [location.search, route.mode])
 
   return route.mode === 'solo'
-    ? <MobCodeManager sessionIdOverride={sessionData.sessionId} soloEditToken={route.soloEditToken} />
+    ? <MobCodeManager sessionIdOverride={sessionData.sessionId} soloEditToken={route.soloEditToken} soloMode />
     : <MobCodeLiveStudent sessionData={sessionData} />
 }
 
@@ -160,6 +161,7 @@ function MobCodeLiveStudent({ sessionData }: MobCodeStudentProps) {
   const [runnerMessage, setRunnerMessage] = useState('')
   const [theme, setTheme] = useState<MobCodeThemeId>(() => getThemeFromCookie())
   const [instructorPresence, setInstructorPresence] = useState<MobCodeEditorPresencePayload | null>(null)
+  const [canResumeSolo, setCanResumeSolo] = useState(false)
   const latestFilesRef = useRef<Record<string, string>>({})
 
   useEffect(() => {
@@ -174,6 +176,7 @@ function MobCodeLiveStudent({ sessionData }: MobCodeStudentProps) {
         setRunnerId(isMobCodeRunnerId(session.data?.runnerId) ? session.data.runnerId : DEFAULT_MOB_CODE_RUNNER_ID)
         setRunnerMessage('')
         setInstructorPresence(null)
+        setCanResumeSolo(session.data?.canEditSolo === true)
       })
       .catch((error) => console.error('Failed to fetch MobCode session:', error))
   }, [encodedSessionId, sessionId])
@@ -254,6 +257,10 @@ function MobCodeLiveStudent({ sessionData }: MobCodeStudentProps) {
 
   const editorThemeClassName = `mobcode-editor-theme-${theme}`
   const studentRunners = getStudentRunnerOptions(runnerId)
+
+  if (canResumeSolo) {
+    return <MobCodeManager sessionIdOverride={sessionId} soloMode />
+  }
 
   return (
     <div className="mobcode-shell">

--- a/activities/mobcode/client/student/MobCodeStudent.tsx
+++ b/activities/mobcode/client/student/MobCodeStudent.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { useLocation } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 import VirtualFileExplorer from '@src/components/common/VirtualFileExplorer'
 import { useResilientWebSocket } from '@src/hooks/useResilientWebSocket'
 import { useSessionEndedHandler } from '@src/hooks/useSessionEndedHandler'
@@ -158,24 +158,22 @@ export function getStudentRunnerOptions(
 
 export default function MobCodeStudent({ sessionData }: MobCodeStudentProps) {
   const location = useLocation()
-  const [route] = useState(() => resolveMobCodeStudentRoute(location.search, location.state, location.hash))
+  const navigate = useNavigate()
+  const route = resolveMobCodeStudentRoute(location.search, location.state, location.hash)
 
   useEffect(() => {
-    if (route.mode !== 'solo' || typeof window === 'undefined') return
+    if (route.mode !== 'solo') return
     const nextSearch = removeMobCodeSoloTokenFromSearch(location.search)
     const nextHash = removeMobCodeSoloTokenFromHash(location.hash)
-    const currentState = window.history.state != null && typeof window.history.state === 'object'
-      ? window.history.state as Record<string, unknown>
+    if (nextSearch === location.search && nextHash === location.hash) return
+    const currentRouterState = location.state != null && typeof location.state === 'object'
+      ? location.state as Record<string, unknown>
       : {}
-    const currentRouterState = currentState.usr != null && typeof currentState.usr === 'object'
-      ? currentState.usr as Record<string, unknown>
-      : {}
-    window.history.replaceState(
-      { ...currentState, usr: { ...currentRouterState, mobcodeSoloToken: route.soloEditToken } },
-      '',
-      `${window.location.pathname}${nextSearch}${nextHash}`,
-    )
-  }, [location.hash, location.search, route])
+    void navigate(`${location.pathname}${nextSearch}${nextHash}`, {
+      replace: true,
+      state: { ...currentRouterState, mobcodeSoloToken: route.soloEditToken },
+    })
+  }, [location.hash, location.pathname, location.search, location.state, navigate, route])
 
   return route.mode === 'solo'
     ? <MobCodeManager sessionIdOverride={sessionData.sessionId} soloEditToken={route.soloEditToken} soloMode />

--- a/activities/mobcode/client/student/MobCodeStudent.tsx
+++ b/activities/mobcode/client/student/MobCodeStudent.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { useLocation } from 'react-router-dom'
 import VirtualFileExplorer from '@src/components/common/VirtualFileExplorer'
 import { useResilientWebSocket } from '@src/hooks/useResilientWebSocket'
 import { useSessionEndedHandler } from '@src/hooks/useSessionEndedHandler'
@@ -17,6 +18,7 @@ import { MOB_CODE_MESSAGE_TYPES } from '../utils/constants'
 import { resolveActiveFile, sanitizeFilesMap } from '../utils/fileUtils'
 import { getThemeFromCookie, setThemeCookie } from '../utils/themeUtils'
 import { isStatePayload, parseMobCodeMessage } from '../manager/managerUtils'
+import MobCodeManager from '../manager/MobCodeManager'
 import '../styles.css'
 
 interface MobCodeStudentProps {
@@ -118,6 +120,15 @@ export function getStudentRunnerOptions(
 }
 
 export default function MobCodeStudent({ sessionData }: MobCodeStudentProps) {
+  const location = useLocation()
+  const soloEditToken = new URLSearchParams(location.search).get('mobcodeSoloToken')
+
+  return soloEditToken
+    ? <MobCodeManager sessionIdOverride={sessionData.sessionId} soloEditToken={soloEditToken} />
+    : <MobCodeLiveStudent sessionData={sessionData} />
+}
+
+function MobCodeLiveStudent({ sessionData }: MobCodeStudentProps) {
   const { sessionId } = sessionData
   const encodedSessionId = encodeURIComponent(sessionId)
   const attachSessionEndedHandler = useSessionEndedHandler()

--- a/activities/mobcode/client/student/MobCodeStudent.tsx
+++ b/activities/mobcode/client/student/MobCodeStudent.tsx
@@ -32,8 +32,15 @@ export type MobCodeStudentRoute =
   | { mode: 'live' }
 
 export function resolveMobCodeStudentRoute(search: string): MobCodeStudentRoute {
-  const soloEditToken = new URLSearchParams(search).get('mobcodeSoloToken')
+  const soloEditToken = new URLSearchParams(search).get('mobcodeSoloToken')?.trim()
   return soloEditToken ? { mode: 'solo', soloEditToken } : { mode: 'live' }
+}
+
+export function removeMobCodeSoloTokenFromSearch(search: string): string {
+  const params = new URLSearchParams(search)
+  params.delete('mobcodeSoloToken')
+  const remainingSearch = params.toString()
+  return remainingSearch ? `?${remainingSearch}` : ''
 }
 
 interface SessionResponse {
@@ -130,7 +137,13 @@ export function getStudentRunnerOptions(
 
 export default function MobCodeStudent({ sessionData }: MobCodeStudentProps) {
   const location = useLocation()
-  const route = resolveMobCodeStudentRoute(location.search)
+  const [route] = useState(() => resolveMobCodeStudentRoute(location.search))
+
+  useEffect(() => {
+    if (route.mode !== 'solo' || typeof window === 'undefined') return
+    const nextSearch = removeMobCodeSoloTokenFromSearch(location.search)
+    window.history.replaceState(window.history.state, '', `${window.location.pathname}${nextSearch}${window.location.hash}`)
+  }, [location.search, route.mode])
 
   return route.mode === 'solo'
     ? <MobCodeManager sessionIdOverride={sessionData.sessionId} soloEditToken={route.soloEditToken} />

--- a/activities/mobcode/client/student/MobCodeStudent.tsx
+++ b/activities/mobcode/client/student/MobCodeStudent.tsx
@@ -31,8 +31,15 @@ export type MobCodeStudentRoute =
   | { mode: 'solo'; soloEditToken: string }
   | { mode: 'live' }
 
-export function resolveMobCodeStudentRoute(search: string): MobCodeStudentRoute {
+function readMobCodeSoloTokenFromHistoryState(locationState: unknown): string {
+  if (locationState == null || typeof locationState !== 'object') return ''
+  const token = (locationState as { mobcodeSoloToken?: unknown }).mobcodeSoloToken
+  return typeof token === 'string' ? token.trim() : ''
+}
+
+export function resolveMobCodeStudentRoute(search: string, locationState?: unknown): MobCodeStudentRoute {
   const soloEditToken = new URLSearchParams(search).get('mobcodeSoloToken')?.trim()
+    || readMobCodeSoloTokenFromHistoryState(locationState)
   return soloEditToken ? { mode: 'solo', soloEditToken } : { mode: 'live' }
 }
 
@@ -138,13 +145,20 @@ export function getStudentRunnerOptions(
 
 export default function MobCodeStudent({ sessionData }: MobCodeStudentProps) {
   const location = useLocation()
-  const [route] = useState(() => resolveMobCodeStudentRoute(location.search))
+  const [route] = useState(() => resolveMobCodeStudentRoute(location.search, location.state))
 
   useEffect(() => {
     if (route.mode !== 'solo' || typeof window === 'undefined') return
     const nextSearch = removeMobCodeSoloTokenFromSearch(location.search)
-    window.history.replaceState(window.history.state, '', `${window.location.pathname}${nextSearch}${window.location.hash}`)
-  }, [location.search, route.mode])
+    const currentState = window.history.state != null && typeof window.history.state === 'object'
+      ? window.history.state as Record<string, unknown>
+      : {}
+    window.history.replaceState(
+      { ...currentState, mobcodeSoloToken: route.soloEditToken },
+      '',
+      `${window.location.pathname}${nextSearch}${window.location.hash}`,
+    )
+  }, [location.search, route])
 
   return route.mode === 'solo'
     ? <MobCodeManager sessionIdOverride={sessionData.sessionId} soloEditToken={route.soloEditToken} soloMode />

--- a/activities/mobcode/server/routes.test.ts
+++ b/activities/mobcode/server/routes.test.ts
@@ -23,7 +23,9 @@ type RouteHandler = (
 interface MockResponse {
   statusCode: number
   body: unknown
+  headers: Record<string, string>
   status(code: number): MockResponse
+  set(name: string, value: string): MockResponse
   json(payload: unknown): MockResponse
 }
 
@@ -31,8 +33,13 @@ function createResponse(): MockResponse {
   return {
     statusCode: 200,
     body: null,
+    headers: {},
     status(code: number) {
       this.statusCode = code
+      return this
+    },
+    set(name: string, value: string) {
+      this.headers[name] = value
       return this
     },
     json(payload: unknown) {
@@ -161,6 +168,7 @@ void test('POST /api/mobcode/create-solo creates a server-backed editable worksp
   assert.equal(response.statusCode, 200)
   assert.equal(typeof (response.body as { id?: unknown }).id, 'string')
   assert.equal(typeof (response.body as { soloEditToken?: unknown }).soloEditToken, 'string')
+  assert.equal(response.headers['Cache-Control'], 'no-store')
   if (savedSession === null) throw new Error('Expected solo session to be saved')
   const data = (savedSession as SessionRecord & { data: ReturnType<typeof normalizeMobCodeSessionData> }).data
   assert.equal(data.soloMode, true)
@@ -201,6 +209,30 @@ void test('GET /api/mobcode/:sessionId/session does not leak instructor passcode
     Object.hasOwn((response.body as { data: { groups: unknown; instructorPasscode?: unknown } }).data, 'instructorPasscode'),
     false,
   )
+})
+
+void test('GET /api/mobcode/:sessionId/session does not leak a solo edit token', async () => {
+  const app = createMockApp()
+  const ws = createMockWs()
+  const session = createMobCodeSessionRecord({
+    data: normalizeMobCodeSessionData({
+      soloMode: true,
+      soloEditToken: 'solo-edit-token',
+      groups: { default: { files: { 'main.py': 'print(1)' }, activeFile: 'main.py' } },
+    }),
+  })
+  setupMobCodeRoutes(app as never, {
+    async get(id: string) { return id === session.id ? session : null },
+    async set() {},
+  }, ws as never)
+
+  const handler = app.handlers.get['/api/mobcode/:sessionId/session']
+  assert.ok(handler)
+  const response = createResponse()
+  await handler({ params: { sessionId: session.id } } as never, response as never)
+
+  assert.equal(response.statusCode, 200)
+  assert.equal(Object.hasOwn((response.body as { data: Record<string, unknown> }).data, 'soloEditToken'), false)
 })
 
 void test('GET /api/mobcode/:sessionId/session exposes sanitized embedded runner id', async () => {

--- a/activities/mobcode/server/routes.test.ts
+++ b/activities/mobcode/server/routes.test.ts
@@ -133,6 +133,41 @@ void test('normalizeMobCodeSessionData creates default group when missing', () =
   assert.equal(data.instructorPasscode?.length, 32)
 })
 
+void test('POST /api/mobcode/create-solo creates a server-backed editable workspace from starter files', async () => {
+  const app = createMockApp()
+  const ws = createMockWs()
+  let savedSession: SessionRecord | null = null
+  setupMobCodeRoutes(app as never, {
+    async get() {
+      return null
+    },
+    async set(_id: string, session: SessionRecord) {
+      savedSession = session
+    },
+  }, ws as never)
+
+  const handler = app.handlers.post['/api/mobcode/create-solo']
+  assert.ok(handler)
+  const response = createResponse()
+  await handler({
+    params: {},
+    body: {
+      files: { 'starter.py': 'print("ready")', '../ignored.py': 'nope' },
+      activeFile: 'starter.py',
+      runnerId: 'brython-terminal',
+    },
+  } as unknown as Parameters<typeof handler>[0], response as unknown as Parameters<typeof handler>[1])
+
+  assert.equal(response.statusCode, 200)
+  assert.equal(typeof (response.body as { id?: unknown }).id, 'string')
+  assert.equal(typeof (response.body as { soloEditToken?: unknown }).soloEditToken, 'string')
+  if (savedSession === null) throw new Error('Expected solo session to be saved')
+  const data = (savedSession as SessionRecord & { data: ReturnType<typeof normalizeMobCodeSessionData> }).data
+  assert.equal(data.soloMode, true)
+  assert.deepEqual(data.groups.default, { files: { 'starter.py': 'print("ready")' }, activeFile: 'starter.py' })
+  assert.equal(data.soloEditToken, (response.body as { soloEditToken: string }).soloEditToken)
+})
+
 void test('GET /api/mobcode/:sessionId/session does not leak instructor passcode', async () => {
   const app = createMockApp()
   const ws = createMockWs()
@@ -159,6 +194,7 @@ void test('GET /api/mobcode/:sessionId/session does not leak instructor passcode
     data: {
       groups: session.data.groups,
       runnerId: null,
+      soloMode: false,
     },
   })
   assert.equal(
@@ -208,6 +244,7 @@ void test('GET /api/mobcode/:sessionId/session exposes sanitized embedded runner
     data: {
       groups: session.data.groups,
       runnerId: 'brython-terminal',
+      soloMode: false,
     },
   })
 })
@@ -253,6 +290,7 @@ void test('GET /api/mobcode/:sessionId/session drops invalid embedded runner id'
     data: {
       groups: session.data.groups,
       runnerId: null,
+      soloMode: false,
     },
   })
 })
@@ -287,6 +325,41 @@ void test('POST /api/mobcode/:sessionId/state returns 403 for a bad instructor p
   assert.equal(response.statusCode, 403)
   assert.deepEqual(response.body, { error: 'Forbidden' })
   assert.equal(setCalls, 0)
+})
+
+void test('POST /api/mobcode/:sessionId/state accepts the scoped solo edit token', async () => {
+  const app = createMockApp()
+  const ws = createMockWs()
+  const session = createMobCodeSessionRecord({
+    data: normalizeMobCodeSessionData({
+      soloMode: true,
+      soloEditToken: 'solo-edit-token',
+      groups: { default: { files: { 'main.py': 'print(1)' }, activeFile: 'main.py' } },
+    }),
+  })
+  let saved: SessionRecord | null = null
+  setupMobCodeRoutes(app as never, {
+    async get(id: string) { return id === session.id ? session : null },
+    async set(_id: string, nextSession: SessionRecord) { saved = nextSession },
+  }, ws as never)
+
+  const handler = app.handlers.post['/api/mobcode/:sessionId/state']
+  assert.ok(handler)
+  const response = createResponse()
+  await handler({
+    params: { sessionId: session.id },
+    body: {
+      soloEditToken: 'solo-edit-token',
+      files: { 'main.py': 'print(2)' },
+      activeFile: 'main.py',
+    },
+  } as unknown as Parameters<typeof handler>[0], response as unknown as Parameters<typeof handler>[1])
+
+  assert.equal(response.statusCode, 200)
+  if (saved === null) throw new Error('Expected solo state to be saved')
+  const savedGroup = (saved as SessionRecord & { data: ReturnType<typeof normalizeMobCodeSessionData> }).data.groups.default
+  if (!savedGroup) throw new Error('Expected saved default group')
+  assert.equal(savedGroup.files['main.py'] ?? '', 'print(2)')
 })
 
 void test('POST /api/mobcode/:sessionId/state returns 400 for an invalid payload', async () => {

--- a/activities/mobcode/server/routes.test.ts
+++ b/activities/mobcode/server/routes.test.ts
@@ -24,8 +24,10 @@ interface MockResponse {
   statusCode: number
   body: unknown
   headers: Record<string, string>
+  cookies: Array<{ name: string; value: string; options: Record<string, unknown> }>
   status(code: number): MockResponse
   set(name: string, value: string): MockResponse
+  cookie(name: string, value: string, options: Record<string, unknown>): MockResponse
   json(payload: unknown): MockResponse
 }
 
@@ -34,12 +36,17 @@ function createResponse(): MockResponse {
     statusCode: 200,
     body: null,
     headers: {},
+    cookies: [],
     status(code: number) {
       this.statusCode = code
       return this
     },
     set(name: string, value: string) {
       this.headers[name] = value
+      return this
+    },
+    cookie(name: string, value: string, options: Record<string, unknown>) {
+      this.cookies.push({ name, value, options })
       return this
     },
     json(payload: unknown) {
@@ -169,6 +176,8 @@ void test('POST /api/mobcode/create-solo creates a server-backed editable worksp
   assert.equal(typeof (response.body as { id?: unknown }).id, 'string')
   assert.equal(typeof (response.body as { soloEditToken?: unknown }).soloEditToken, 'string')
   assert.equal(response.headers['Cache-Control'], 'no-store')
+  assert.equal(response.cookies.length, 1)
+  assert.equal(response.cookies[0]?.options.httpOnly, true)
   if (savedSession === null) throw new Error('Expected solo session to be saved')
   const data = (savedSession as SessionRecord & { data: ReturnType<typeof normalizeMobCodeSessionData> }).data
   assert.equal(data.soloMode, true)
@@ -203,6 +212,7 @@ void test('GET /api/mobcode/:sessionId/session does not leak instructor passcode
       groups: session.data.groups,
       runnerId: null,
       soloMode: false,
+      canEditSolo: false,
     },
   })
   assert.equal(
@@ -277,6 +287,7 @@ void test('GET /api/mobcode/:sessionId/session exposes sanitized embedded runner
       groups: session.data.groups,
       runnerId: 'brython-terminal',
       soloMode: false,
+      canEditSolo: false,
     },
   })
 })
@@ -323,6 +334,7 @@ void test('GET /api/mobcode/:sessionId/session drops invalid embedded runner id'
       groups: session.data.groups,
       runnerId: null,
       soloMode: false,
+      canEditSolo: false,
     },
   })
 })

--- a/activities/mobcode/server/routes.test.ts
+++ b/activities/mobcode/server/routes.test.ts
@@ -178,6 +178,7 @@ void test('POST /api/mobcode/create-solo creates a server-backed editable worksp
   assert.equal(response.headers['Cache-Control'], 'no-store')
   assert.equal(response.cookies.length, 1)
   assert.equal(response.cookies[0]?.options.httpOnly, true)
+  assert.equal(response.cookies[0]?.options.maxAge, 365 * 24 * 60 * 60 * 1000)
   if (savedSession === null) throw new Error('Expected solo session to be saved')
   const data = (savedSession as SessionRecord & { data: ReturnType<typeof normalizeMobCodeSessionData> }).data
   assert.equal(data.soloMode, true)

--- a/activities/mobcode/server/routes.test.ts
+++ b/activities/mobcode/server/routes.test.ts
@@ -16,7 +16,7 @@ import {
 import setupMobCodeRoutes from './routes'
 
 type RouteHandler = (
-  req: { params: Record<string, string>; body?: unknown },
+  req: { params: Record<string, string>; body?: unknown; headers?: { cookie?: string } },
   res: MockResponse,
 ) => Promise<void> | void
 
@@ -246,6 +246,33 @@ void test('GET /api/mobcode/:sessionId/session does not leak a solo edit token',
   assert.equal(Object.hasOwn((response.body as { data: Record<string, unknown> }).data, 'soloEditToken'), false)
 })
 
+void test('GET /api/mobcode/:sessionId/session enables solo editing for the matching cookie', async () => {
+  const app = createMockApp()
+  const ws = createMockWs()
+  const session = createMobCodeSessionRecord({
+    data: normalizeMobCodeSessionData({
+      soloMode: true,
+      soloEditToken: 'solo-edit-token',
+      groups: { default: { files: { 'main.py': 'print(1)' }, activeFile: 'main.py' } },
+    }),
+  })
+  setupMobCodeRoutes(app as never, {
+    async get(id: string) { return id === session.id ? session : null },
+    async set() {},
+  }, ws as never)
+
+  const handler = app.handlers.get['/api/mobcode/:sessionId/session']
+  assert.ok(handler)
+  const response = createResponse()
+  await handler({
+    params: { sessionId: session.id },
+    headers: { cookie: `mobcode_solo_edit_${session.id}=solo-edit-token` },
+  } as never, response as never)
+
+  assert.equal(response.statusCode, 200)
+  assert.equal((response.body as { data: { canEditSolo: boolean } }).data.canEditSolo, true)
+})
+
 void test('GET /api/mobcode/:sessionId/session exposes sanitized embedded runner id', async () => {
   const app = createMockApp()
   const ws = createMockWs()
@@ -399,6 +426,41 @@ void test('POST /api/mobcode/:sessionId/state accepts the scoped solo edit token
       activeFile: 'main.py',
     },
   } as unknown as Parameters<typeof handler>[0], response as unknown as Parameters<typeof handler>[1])
+
+  assert.equal(response.statusCode, 200)
+  if (saved === null) throw new Error('Expected solo state to be saved')
+  const savedGroup = (saved as SessionRecord & { data: ReturnType<typeof normalizeMobCodeSessionData> }).data.groups.default
+  if (!savedGroup) throw new Error('Expected saved default group')
+  assert.equal(savedGroup.files['main.py'] ?? '', 'print(2)')
+})
+
+void test('POST /api/mobcode/:sessionId/state accepts the matching solo edit cookie', async () => {
+  const app = createMockApp()
+  const ws = createMockWs()
+  const session = createMobCodeSessionRecord({
+    data: normalizeMobCodeSessionData({
+      soloMode: true,
+      soloEditToken: 'solo-edit-token',
+      groups: { default: { files: { 'main.py': 'print(1)' }, activeFile: 'main.py' } },
+    }),
+  })
+  let saved: SessionRecord | null = null
+  setupMobCodeRoutes(app as never, {
+    async get(id: string) { return id === session.id ? session : null },
+    async set(_id: string, nextSession: SessionRecord) { saved = nextSession },
+  }, ws as never)
+
+  const handler = app.handlers.post['/api/mobcode/:sessionId/state']
+  assert.ok(handler)
+  const response = createResponse()
+  await handler({
+    params: { sessionId: session.id },
+    headers: { cookie: `mobcode_solo_edit_${session.id}=solo-edit-token` },
+    body: {
+      files: { 'main.py': 'print(2)' },
+      activeFile: 'main.py',
+    },
+  } as never, response as never)
 
   assert.equal(response.statusCode, 200)
   if (saved === null) throw new Error('Expected solo state to be saved')

--- a/activities/mobcode/server/routes.test.ts
+++ b/activities/mobcode/server/routes.test.ts
@@ -205,6 +205,7 @@ void test('GET /api/mobcode/:sessionId/session does not leak instructor passcode
   } as unknown as Parameters<typeof sessionHandler>[0], response as unknown as Parameters<typeof sessionHandler>[1])
 
   assert.equal(response.statusCode, 200)
+  assert.equal(response.headers['Cache-Control'], 'no-store')
   assert.deepEqual(response.body, {
     id: session.id,
     type: session.type,

--- a/activities/mobcode/server/routes.ts
+++ b/activities/mobcode/server/routes.ts
@@ -702,6 +702,9 @@ export default function setupMobCodeRoutes(app: AppLike, sessions: MobCodeSessio
       }
       await sessions.set(session.id, session)
       await broadcast(messageType, nextPayload, session.id)
+      if (session.data.soloMode === true) {
+        scheduleLiveGroupCleanup(session.id)
+      }
       res.json({ ok: true })
     } catch (error) {
       console.error(JSON.stringify({ event: 'mobcode.state-failed', sessionId: req.params.sessionId, error: String(error) }))

--- a/activities/mobcode/server/routes.ts
+++ b/activities/mobcode/server/routes.ts
@@ -214,6 +214,22 @@ function createSoloEditToken(): string {
   return randomBytes(SOLO_EDIT_TOKEN_BYTES).toString('hex')
 }
 
+function getSoloEditCookieName(sessionId: string): string {
+  return `mobcode_solo_edit_${sessionId}`
+}
+
+function readRequestCookie(req: Request, name: string): string | null {
+  const cookieHeader = req.headers?.cookie
+  if (typeof cookieHeader !== 'string') return null
+  const cookie = cookieHeader.split(';').map((entry) => entry.trim()).find((entry) => entry.startsWith(`${name}=`))
+  if (!cookie) return null
+  try {
+    return decodeURIComponent(cookie.slice(name.length + 1))
+  } catch {
+    return null
+  }
+}
+
 function verifyPasscode(expected: string | undefined, candidate: unknown): boolean {
   if (typeof expected !== 'string' || typeof candidate !== 'string') return false
   if (
@@ -603,6 +619,12 @@ export default function setupMobCodeRoutes(app: AppLike, sessions: MobCodeSessio
       session.type = 'mobcode'
       await sessions.set(session.id, session)
       console.info(JSON.stringify({ event: 'mobcode.solo-session-created', sessionId: session.id, fileCount: Object.keys(files).length }))
+      res.cookie(getSoloEditCookieName(session.id), soloEditToken, {
+        httpOnly: true,
+        sameSite: 'lax',
+        secure: process.env.NODE_ENV === 'production',
+        path: `/api/mobcode/${encodeURIComponent(session.id)}`,
+      })
       res.set('Cache-Control', 'no-store')
       res.json({ id: session.id, soloEditToken })
     } catch (error) {
@@ -625,6 +647,8 @@ export default function setupMobCodeRoutes(app: AppLike, sessions: MobCodeSessio
           groups: session.data.groups,
           runnerId: readEmbeddedRunnerId(session.data),
           soloMode: session.data.soloMode === true,
+          canEditSolo: session.data.soloMode === true
+            && verifyPasscode(session.data.soloEditToken, readRequestCookie(req, getSoloEditCookieName(session.id))),
         },
       })
     } catch (error) {
@@ -643,7 +667,10 @@ export default function setupMobCodeRoutes(app: AppLike, sessions: MobCodeSessio
       const body = isPlainObject(req.body) ? req.body : {}
       const hasInstructorAccess = verifyPasscode(session.data.instructorPasscode, body.instructorPasscode)
       const hasSoloEditAccess = session.data.soloMode === true
-        && verifyPasscode(session.data.soloEditToken, body.soloEditToken)
+        && (
+          verifyPasscode(session.data.soloEditToken, body.soloEditToken)
+          || verifyPasscode(session.data.soloEditToken, readRequestCookie(req, getSoloEditCookieName(session.id)))
+        )
       if (!hasInstructorAccess && !hasSoloEditAccess) {
         console.warn(JSON.stringify({ event: 'mobcode.state-denied', sessionId: session.id }))
         res.status(403).json({ error: 'Forbidden' })

--- a/activities/mobcode/server/routes.ts
+++ b/activities/mobcode/server/routes.ts
@@ -51,6 +51,7 @@ const MAX_FILE_CONTENT_LENGTH = 1_000_000
 const MAX_TOTAL_CONTENT_LENGTH = 4 * 1024 * 1024
 const INSTRUCTOR_PASSCODE_BYTES = 16
 const MAX_INSTRUCTOR_PASSCODE_LENGTH = 512
+const SOLO_EDIT_TOKEN_BYTES = 24
 const MAX_PRESENCE_SELECTIONS = 16
 const WS_OPEN = 1
 const LIVE_GROUP_CLEANUP_DELAY_MS = 30_000
@@ -207,6 +208,10 @@ function asMobCodeSession(session: SessionRecord | null): (SessionRecord & { dat
 
 function createInstructorPasscode(): string {
   return randomBytes(INSTRUCTOR_PASSCODE_BYTES).toString('hex')
+}
+
+function createSoloEditToken(): string {
+  return randomBytes(SOLO_EDIT_TOKEN_BYTES).toString('hex')
 }
 
 function verifyPasscode(expected: string | undefined, candidate: unknown): boolean {
@@ -580,6 +585,31 @@ export default function setupMobCodeRoutes(app: AppLike, sessions: MobCodeSessio
     }
   })
 
+  app.post('/api/mobcode/create-solo', async (req, res) => {
+    try {
+      const body = isPlainObject(req.body) ? req.body : {}
+      const files = normalizeFiles(body.files)
+      const activeFile = resolveActiveFile(files, body.activeFile)
+      const runnerId = isMobCodeRunnerId(body.runnerId) ? body.runnerId : undefined
+      const soloEditToken = createSoloEditToken()
+      const session = await createSession(sessions, {
+        data: normalizeMobCodeSessionData({
+          groups: { [DEFAULT_GROUP_ID]: { files, activeFile } },
+          soloMode: true,
+          soloEditToken,
+          ...(runnerId ? { embeddedLaunch: { selectedOptions: { runnerId } } } : {}),
+        }),
+      })
+      session.type = 'mobcode'
+      await sessions.set(session.id, session)
+      console.info(JSON.stringify({ event: 'mobcode.solo-session-created', sessionId: session.id, fileCount: Object.keys(files).length }))
+      res.json({ id: session.id, soloEditToken })
+    } catch (error) {
+      console.error(JSON.stringify({ event: 'mobcode.solo-create-failed', error: String(error) }))
+      res.status(500).json({ error: 'Failed to create solo session' })
+    }
+  })
+
   app.get('/api/mobcode/:sessionId/session', async (req, res) => {
     try {
       const session = asMobCodeSession(await sessions.get(readParam(req.params.sessionId)))
@@ -593,6 +623,7 @@ export default function setupMobCodeRoutes(app: AppLike, sessions: MobCodeSessio
         data: {
           groups: session.data.groups,
           runnerId: readEmbeddedRunnerId(session.data),
+          soloMode: session.data.soloMode === true,
         },
       })
     } catch (error) {
@@ -609,7 +640,10 @@ export default function setupMobCodeRoutes(app: AppLike, sessions: MobCodeSessio
         return
       }
       const body = isPlainObject(req.body) ? req.body : {}
-      if (!verifyPasscode(session.data.instructorPasscode, body.instructorPasscode)) {
+      const hasInstructorAccess = verifyPasscode(session.data.instructorPasscode, body.instructorPasscode)
+      const hasSoloEditAccess = session.data.soloMode === true
+        && verifyPasscode(session.data.soloEditToken, body.soloEditToken)
+      if (!hasInstructorAccess && !hasSoloEditAccess) {
         console.warn(JSON.stringify({ event: 'mobcode.state-denied', sessionId: session.id }))
         res.status(403).json({ error: 'Forbidden' })
         return

--- a/activities/mobcode/server/routes.ts
+++ b/activities/mobcode/server/routes.ts
@@ -640,6 +640,7 @@ export default function setupMobCodeRoutes(app: AppLike, sessions: MobCodeSessio
         res.status(404).json({ error: 'Session not found' })
         return
       }
+      res.set('Cache-Control', 'no-store')
       res.json({
         id: session.id,
         type: session.type,

--- a/activities/mobcode/server/routes.ts
+++ b/activities/mobcode/server/routes.ts
@@ -603,6 +603,7 @@ export default function setupMobCodeRoutes(app: AppLike, sessions: MobCodeSessio
       session.type = 'mobcode'
       await sessions.set(session.id, session)
       console.info(JSON.stringify({ event: 'mobcode.solo-session-created', sessionId: session.id, fileCount: Object.keys(files).length }))
+      res.set('Cache-Control', 'no-store')
       res.json({ id: session.id, soloEditToken })
     } catch (error) {
       console.error(JSON.stringify({ event: 'mobcode.solo-create-failed', error: String(error) }))

--- a/activities/mobcode/server/routes.ts
+++ b/activities/mobcode/server/routes.ts
@@ -55,6 +55,7 @@ const SOLO_EDIT_TOKEN_BYTES = 24
 const MAX_PRESENCE_SELECTIONS = 16
 const WS_OPEN = 1
 const LIVE_GROUP_CLEANUP_DELAY_MS = 30_000
+const SOLO_EDIT_COOKIE_MAX_AGE_MS = 365 * 24 * 60 * 60 * 1000
 const DURABLE_MESSAGE_TYPES = new Set<MobCodeMessage['type']>(['state-sync', 'file-tree-changed'])
 const RESERVED_PATH_SEGMENTS = new Set(['__proto__', 'constructor', 'prototype'])
 
@@ -621,6 +622,7 @@ export default function setupMobCodeRoutes(app: AppLike, sessions: MobCodeSessio
       console.info(JSON.stringify({ event: 'mobcode.solo-session-created', sessionId: session.id, fileCount: Object.keys(files).length }))
       res.cookie(getSoloEditCookieName(session.id), soloEditToken, {
         httpOnly: true,
+        maxAge: SOLO_EDIT_COOKIE_MAX_AGE_MS,
         sameSite: 'lax',
         secure: process.env.NODE_ENV === 'production',
         path: `/api/mobcode/${encodeURIComponent(session.id)}`,

--- a/activities/mobcode/shared/types.ts
+++ b/activities/mobcode/shared/types.ts
@@ -6,6 +6,9 @@ export interface MobCodeGroupState {
 export interface MobCodeSessionData extends Record<string, unknown> {
   groups: Record<string, MobCodeGroupState>
   instructorPasscode?: string
+  /** Opaque, per-session credential for a self-paced student workspace. */
+  soloEditToken?: string
+  soloMode?: boolean
 }
 
 export type MobCodeStatePayload = MobCodeGroupState

--- a/skills/syncdeck/references/ACTIVITY_PAYLOADS.md
+++ b/skills/syncdeck/references/ACTIVITY_PAYLOADS.md
@@ -291,7 +291,7 @@ Postboard reads `embeddedLaunch.selectedOptions.prompt` and `embeddedLaunch.sele
 
 ### Deck launch payload
 
-MobCode can seed starter files for an embedded live coding session.
+MobCode can seed starter files for an embedded live coding session or a student-owned solo workspace.
 
 Example:
 
@@ -315,6 +315,8 @@ Field guidance:
 ### Child embedded launch state
 
 MobCode reads `embeddedLaunch.selectedOptions.files` and `embeddedLaunch.selectedOptions.activeFile` only when the child session is first created without an existing MobCode file tree. After that, the live session state under `groups.default` is authoritative, so later reloads or reconnects do not overwrite instructor edits with the original starter payload.
+
+When SyncDeck is in solo mode, MobCode creates a distinct server-backed self-paced workspace from this same payload for the student who launches it. The student receives an opaque scoped edit token for that workspace; it is not an instructor passcode. The workspace state can therefore be retained for later activity reporting, unlike a browser-only editor.
 
 MobCode also reads `embeddedLaunch.selectedOptions.runnerId` through the child session API so the instructor and students use the instructor-selected runner. The current supported value is `brython-terminal`; unsupported values are ignored and the activity falls back to the default runner. In the student view, available runner options collapse to the instructor-selected runner so students cannot switch to a different implementation.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled standalone MobCode solo workspaces with shareable permalinks.
  * Added a persistent solo session creation flow that returns a scoped solo edit token for later edits.
  * Solo mode now powers a dedicated solo workspace UI and disables live collaboration/sync.

* **Documentation**
  * Updated MobCode/SyncDeck documentation to describe solo-mode seeding, access, and embedded launch behavior.

* **Tests**
  * Added integration and unit tests for solo workspace creation, navigation, authorization, token secrecy, and state persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->