### PR TITLE
Fix MobCode blank Python runner files

### DIFF
--- a/.agent/knowledge/testing-patterns.md
+++ b/.agent/knowledge/testing-patterns.md
@@ -15,6 +15,15 @@ Capture reusable test setup patterns, common failure modes, and reliability guid
 
 ## Entries
 
+- Date: 2026-07-26
+- Scope: unit | e2e | MobCode Python runner
+- Pattern: When wrapping user Python in a function, treat blank and comment-only source as an empty suite and emit `pass`; test both source shapes in the real Brython popup as well as the source builder.
+- Why it helps: Indented comments and blank lines do not satisfy Python's requirement for a function body, so string-presence checks can generate an `IndentationError` even though the user file has no executable code.
+- Example (file/path): `activities/mobcode/client/runner/runnerUtils.ts`; `activities/mobcode/playwright/runner.spec.ts`
+- Failure signal: Running an empty or comment-only Python file reports `expected an indented block` against the generated async wrapper.
+- Follow-up action: Keep this coverage when changing the runner wrapper or source transformations.
+- Owner: Codex
+
 - Date: 2026-07-24
 - Scope: unit | CI
 - Pattern: Keep activity tests free of mutations to `globalThis.window`, `document`, `navigator`, or global browser timers when the activities workspace runs files concurrently; extract browser-timer behavior behind an injected helper and test it with a local timer double instead.

--- a/activities/mobcode/client/runner/runnerUtils.test.ts
+++ b/activities/mobcode/client/runner/runnerUtils.test.ts
@@ -345,6 +345,14 @@ void test('buildBrythonAsyncEntrySource rewrites top-level and function input', 
   assert.match(source, /mobcode_run_async\(__mobcode_run__\(\)\)/)
 })
 
+void test('buildBrythonAsyncEntrySource gives blank and comment-only files a valid body', () => {
+  for (const source of ['', '# Nothing to run\n# Yet']) {
+    const wrappedSource = buildBrythonAsyncEntrySource(source)
+
+    assert.match(wrappedSource, /async def __mobcode_user_main__\(\):\n {4}pass\n/)
+  }
+})
+
 void test('buildBrythonAsyncEntrySource rewrites class method input', () => {
   const source = buildBrythonAsyncEntrySource([
     'class Prompter:',

--- a/activities/mobcode/client/runner/runnerUtils.ts
+++ b/activities/mobcode/client/runner/runnerUtils.ts
@@ -532,7 +532,11 @@ function buildBrythonTransformedSource(
 
     return rewrittenLine
   })
-  const userBody = transformedLines.length > 0
+  const hasExecutableLine = transformedLines.some((line) => {
+    const trimmed = line.trim()
+    return trimmed !== '' && !trimmed.startsWith('#')
+  })
+  const userBody = hasExecutableLine
     ? transformedLines.map((line) => `    ${line}`).join('\n')
     : '    pass'
 

--- a/activities/mobcode/playwright/runner.spec.ts
+++ b/activities/mobcode/playwright/runner.spec.ts
@@ -109,6 +109,20 @@ test('MobCode Python runner popup prints terminal output', async ({ page }) => {
   await clickRunnerDoneAndWaitForClose(popup)
 })
 
+test('MobCode Python runner completes blank and comment-only files', async ({ page }) => {
+  for (const source of ['', '# Nothing to run yet\n']) {
+    const session = await createMobCodeSession(page)
+    await seedMobCodeFile(page, session, source)
+    await openMobCodeManager(page, session)
+
+    const popup = await runMobCodePopup(page)
+    const terminal = popup.locator('#terminal')
+    await expect(popup.getByRole('button', { name: 'Close Python runner' })).toHaveText('Done')
+    await expect(terminal).not.toContainText('IndentationError')
+    await clickRunnerDoneAndWaitForClose(popup)
+  }
+})
+
 test('MobCode Python runner popup imports workspace Python modules', async ({ page }) => {
   const session = await createMobCodeSession(page)
   await seedMobCodeFiles(page, session, {


### PR DESCRIPTION
## Summary

- emit a `pass` body when a MobCode Python entry file is blank or comment-only
- add source-builder and Brython popup regression coverage
- document the wrapper-body testing pattern

## Root cause

The runner treated non-empty transformed text as a valid function body, but indented comments and blank lines do not satisfy Python's suite requirement.

## Validation

- `npm run test:activities:file -- activities/mobcode/client/runner/runnerUtils.test.ts`
- activities runner lint and typecheck
- `npm run test:e2e -- activities/mobcode/playwright/runner.spec.ts` (the new Chromium case passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Python execution for blank files and files containing only comments.
  * These files now run successfully without producing indentation errors.

* **Tests**
  * Added automated coverage for blank and comment-only Python files.
  * Added validation that the runner completes successfully and displays the expected completion state.

* **Documentation**
  * Documented the testing pattern for handling empty Python source files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->