### PR TITLE
Add SyncDeck substitute instructor links

### DIFF
--- a/.agent/knowledge/security-notes.md
+++ b/.agent/knowledge/security-notes.md
@@ -26,9 +26,9 @@ Track security-relevant boundaries, risks, and mitigation decisions.
 - Residual risk: The signed payload is not encrypted and the stateless initial design
   cannot revoke an individual link before expiry.
 - Validation (test/review/path): `activities/syncdeck/server/learnIntegration.ts`;
-  `activities/syncdeck/server/learnIntegration.test.ts`.
-- Follow-up action: Add browser coverage and a controlled expired-link test; use a
-  short class/day expiry from Learn.
+  `activities/syncdeck/server/learnIntegration.test.ts`;
+  `activities/syncdeck/playwright/substitute-instructor-link.spec.ts`.
+- Follow-up action: Use a short class/day expiry from Learn when generating links.
 - Owner: Codex
 
 - Date: 2026-07-15

--- a/.agent/knowledge/security-notes.md
+++ b/.agent/knowledge/security-notes.md
@@ -15,6 +15,22 @@ Track security-relevant boundaries, risks, and mitigation decisions.
 
 ## Notes
 
+- Date: 2026-07-26
+- Area: Learn SyncDeck substitute instructor link
+- Threat or risk: A direct substitute link is a bearer capability that can start or reuse
+  an instructor-led SyncDeck session without LMS access.
+- Control or mitigation: ActiveBits verifies an expiry-bound, canonical base64url payload
+  signed with a domain-separated HMAC context, establishes only httpOnly instructor
+  recovery state, and redirects to a token-free manager URL with no-referrer/no-store
+  headers. It does not log the link payload or signature.
+- Residual risk: The signed payload is not encrypted and the stateless initial design
+  cannot revoke an individual link before expiry.
+- Validation (test/review/path): `activities/syncdeck/server/learnIntegration.ts`;
+  `activities/syncdeck/server/learnIntegration.test.ts`.
+- Follow-up action: Add browser coverage and a controlled expired-link test; use a
+  short class/day expiry from Learn.
+- Owner: Codex
+
 - Date: 2026-07-15
 - Area: waiting-room student display-name persistence
 - Threat or risk: Remembering a student's lobby name across days in browser persistence could inadvertently expand into storing participant IDs, credentials, or activity-specific form data.

--- a/.agent/plans/learn-syncdeck-session-integration.md
+++ b/.agent/plans/learn-syncdeck-session-integration.md
@@ -393,6 +393,75 @@ must redact query strings for these browser handoff paths before production enab
 
 ---
 
+## Direct Substitute Instructor Link (Proposed Extension)
+
+An instructor with Learn access may create a time-bounded substitute-teacher link and
+give it to a substitute who cannot access the LMS. The substitute opens ActiveBits
+directly; Learn is not in the browser redirect path. Students continue to enter through
+their normal Learn/LTI launches and therefore join the same Learn resource mapping.
+
+Learn creates a self-contained signed capability URL. Its canonical payload contains:
+
+```ts
+interface LearnSyncDeckSubstituteLinkPayload {
+  v: 1
+  provider: string
+  resourceLinkId: string
+  presentationUrl: string
+  expiresAt: number             // Unix epoch milliseconds; normally end of class/day
+  jti: string                   // random ID for audit correlation
+}
+```
+
+Learn serializes this payload with the same deterministic JSON rules used by the
+server-to-server HMAC contract, base64url-encodes the UTF-8 bytes, and signs the literal
+base64url payload with the domain-separated value:
+
+```text
+LEARN_SYNCDECK_SUBSTITUTE_LINK\n<payload-base64url>
+```
+
+using HMAC-SHA-256 and the dedicated Learn–ActiveBits shared secret. The result is a URL
+such as:
+
+```text
+https://bits.example/api/syncdeck/learn/substitute?payload=<base64url>&sig=<lowercase-hex>
+```
+
+On navigation, ActiveBits verifies the signature, payload shape, provider, expiration,
+and presentation URL. It then uses the normal deterministic resource mapping to start a
+new instructor-led session or reuse the active one when its presentation URL matches.
+It creates the usual short-lived httpOnly instructor recovery state and redirects to
+`/manage/syncdeck/:sessionId`, stripping `payload` and `sig` from the final URL.
+
+The capability is reusable until expiry; each visit receives fresh browser recovery
+state. It never contains an instructor passcode. It is nevertheless a bearer credential:
+use `Cache-Control: no-store`, `Referrer-Policy: no-referrer`, query-string redaction in
+proxy/access logs, and a bounded expiry. The payload is signed, not encrypted, so a
+presentation URL in it is visible to anyone who has the link.
+
+A purely self-contained signed URL cannot be individually revoked. Learn can set a short
+class/day expiry or rotate the shared key to invalidate all links. If individual
+revocation is required, ActiveBits must additionally store a revocation record keyed by
+`jti`; that is an intentional trade-off against the stateless permalink model.
+
+### Substitute Link Implementation Tasks
+
+- [ ] Learn: provide an instructor-only Generate Substitute Link control, with expiry
+  selection, copy UI, and audit metadata; sign only on the Learn server.
+- [ ] Learn: warn that the URL grants instructor control until expiry and do not store or
+  display ActiveBits credentials.
+- [ ] ActiveBits: add the direct substitute-link verification route, using a signature
+  context distinct from both request HMAC and existing browser handoff tokens.
+- [ ] ActiveBits: reuse the normal mapping/start rules, including `409` for a deck URL
+  mismatch while an instructor-led session is active.
+- [ ] ActiveBits: add tests for valid reuse/start, expired/tampered links, final URL
+  stripping, and the no-passcode/log-redaction boundary.
+- [ ] Decide before implementation whether per-link revocation is required. If yes,
+  define a bounded ActiveBits `jti` revocation store and a Learn revoke action.
+
+---
+
 ## Instructor Browser Handoff
 
 Learn's Start button calls the server-to-server `start` endpoint, then opens

--- a/.agent/plans/learn-syncdeck-session-integration.md
+++ b/.agent/plans/learn-syncdeck-session-integration.md
@@ -455,7 +455,7 @@ does not add a long-term per-link revocation store for this version.
   context distinct from both request HMAC and existing browser handoff tokens.
 - [x] ActiveBits: reuse the normal mapping/start rules, including `409` for a deck URL
   mismatch while an instructor-led session is active.
-- [ ] ActiveBits: add browser coverage for direct-link final URL stripping and recovery
+- [x] ActiveBits: add browser coverage for direct-link final URL stripping and recovery
   cookie behavior. Unit coverage verifies valid reuse and tampered/expired-link
   rejection.
 - [x] Product decision: do not add per-link revocation or long-term ActiveBits storage

--- a/.agent/plans/learn-syncdeck-session-integration.md
+++ b/.agent/plans/learn-syncdeck-session-integration.md
@@ -451,12 +451,13 @@ does not add a long-term per-link revocation store for this version.
   selection, copy UI, and audit metadata; sign only on the Learn server.
 - [ ] Learn: warn that the URL grants instructor control until expiry and do not store or
   display ActiveBits credentials.
-- [ ] ActiveBits: add the direct substitute-link verification route, using a signature
+- [x] ActiveBits: add the direct substitute-link verification route, using a signature
   context distinct from both request HMAC and existing browser handoff tokens.
-- [ ] ActiveBits: reuse the normal mapping/start rules, including `409` for a deck URL
+- [x] ActiveBits: reuse the normal mapping/start rules, including `409` for a deck URL
   mismatch while an instructor-led session is active.
-- [ ] ActiveBits: add tests for valid reuse/start, expired/tampered links, final URL
-  stripping, and the no-passcode/log-redaction boundary.
+- [ ] ActiveBits: add browser coverage for direct-link final URL stripping and recovery
+  cookie behavior. Unit coverage verifies valid reuse and tampered/expired-link
+  rejection.
 - [x] Product decision: do not add per-link revocation or long-term ActiveBits storage
   in the initial version; rely on bounded expiry and coordinated key rotation.
 

--- a/.agent/plans/learn-syncdeck-session-integration.md
+++ b/.agent/plans/learn-syncdeck-session-integration.md
@@ -393,7 +393,7 @@ must redact query strings for these browser handoff paths before production enab
 
 ---
 
-## Direct Substitute Instructor Link (Proposed Extension)
+## Direct Substitute Instructor Link (Approved Extension)
 
 An instructor with Learn access may create a time-bounded substitute-teacher link and
 give it to a substitute who cannot access the LMS. The substitute opens ActiveBits
@@ -440,10 +440,10 @@ use `Cache-Control: no-store`, `Referrer-Policy: no-referrer`, query-string reda
 proxy/access logs, and a bounded expiry. The payload is signed, not encrypted, so a
 presentation URL in it is visible to anyone who has the link.
 
-A purely self-contained signed URL cannot be individually revoked. Learn can set a short
-class/day expiry or rotate the shared key to invalidate all links. If individual
-revocation is required, ActiveBits must additionally store a revocation record keyed by
-`jti`; that is an intentional trade-off against the stateless permalink model.
+A purely self-contained signed URL cannot be individually revoked. The initial
+implementation deliberately uses this stateless permalink model: Learn sets a bounded
+class/day expiry, and shared-key rotation invalidates all links if necessary. ActiveBits
+does not add a long-term per-link revocation store for this version.
 
 ### Substitute Link Implementation Tasks
 
@@ -457,8 +457,8 @@ revocation is required, ActiveBits must additionally store a revocation record k
   mismatch while an instructor-led session is active.
 - [ ] ActiveBits: add tests for valid reuse/start, expired/tampered links, final URL
   stripping, and the no-passcode/log-redaction boundary.
-- [ ] Decide before implementation whether per-link revocation is required. If yes,
-  define a bounded ActiveBits `jti` revocation store and a Learn revoke action.
+- [x] Product decision: do not add per-link revocation or long-term ActiveBits storage
+  in the initial version; rely on bounded expiry and coordinated key rotation.
 
 ---
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -51,6 +51,11 @@ ActiveBits/
 5. Teacher manages the activity from the manager view
 6. Additional instructors can use `Teacher Join` on `/` with the session ID plus teacher code to recover the live manage view
 
+For Learn-managed SyncDeck resources, a substitute teacher can use a time-bounded,
+signed ActiveBits capability URL. ActiveBits verifies the capability, starts or reuses
+the resource's instructor session, establishes its httpOnly recovery state, and redirects
+to the normal SyncDeck manager route without retaining the capability in the final URL.
+
 Teachers can also open `/launch/{activity-id}` to start the same temporary-session flow
 from a URL-addressable launcher. The default launcher page requires a button click before
 creating a session. Adding `?start=1` lets trusted instructor-authored links, such as links

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -129,6 +129,10 @@ ActiveBits supports two session storage modes:
 | `LEARN_SYNCDECK_HMAC_SECRET` | Conditional | (none) | Dedicated shared secret for the Learn SyncDeck server-to-server integration. Leave unset to disable the integration. Never reuse an LTI consumer secret. |
 | `LEARN_SYNCDECK_HMAC_KEY_ID` | No | `learn-default` | Identifies the active Learn SyncDeck HMAC key. Use a new key ID during rotation. |
 
+Learn substitute-instructor capability URLs are signed bearer links. Configure reverse
+proxy and access logging to redact their query strings, and use bounded expiration when
+issuing them from Learn.
+
 ## Source Map Policy (Open-Source Repo)
 
 ActiveBits intentionally ships source maps in production for debugging and teaching transparency.

--- a/README.md
+++ b/README.md
@@ -56,3 +56,7 @@ consumer secret. Set `LEARN_SYNCDECK_HMAC_SECRET` and, optionally,
 `LEARN_SYNCDECK_HMAC_KEY_ID` (default: `learn-default`) only in server-side environment
 configuration. See `.agent/plans/learn-syncdeck-session-integration.md` for the request
 contract and launch lifecycle.
+
+Learn can also issue a time-bounded signed substitute-instructor link that opens a
+SyncDeck instructor session directly in ActiveBits. It is a bearer capability: use a
+bounded expiry and do not expose it in logs or analytics.

--- a/activities/syncdeck/playwright/substitute-instructor-link.spec.ts
+++ b/activities/syncdeck/playwright/substitute-instructor-link.spec.ts
@@ -1,0 +1,49 @@
+import { createHmac, randomUUID } from 'node:crypto'
+import { expect, test } from '@playwright/test'
+
+const hmacSecret = process.env.PLAYWRIGHT_LEARN_SYNCDECK_HMAC_SECRET
+
+function createSubstituteInstructorUrl(): string {
+  if (!hmacSecret) throw new Error('PLAYWRIGHT_LEARN_SYNCDECK_HMAC_SECRET was not configured for the browser test.')
+  const payload = Buffer.from(JSON.stringify({
+    expiresAt: Date.now() + 60_000,
+    jti: randomUUID(),
+    presentationUrl: 'https://slides.example/substitute-instructor-deck',
+    provider: 'playwright-learn',
+    resourceLinkId: `resource-${randomUUID()}`,
+    v: 1,
+  }), 'utf8').toString('base64url')
+  const signature = createHmac('sha256', hmacSecret)
+    .update(`LEARN_SYNCDECK_SUBSTITUTE_LINK\n${payload}`, 'utf8')
+    .digest('hex')
+  return `/api/syncdeck/learn/substitute?payload=${encodeURIComponent(payload)}&sig=${signature}`
+}
+
+test('a signed substitute instructor link opens a recoverable SyncDeck manager without retaining link credentials', async ({ page, context }) => {
+  test.skip(test.info().project.name !== 'chromium', 'WebKit test contexts do not retain Set-Cookie responses from fetch in this harness.')
+
+  await page.goto(createSubstituteInstructorUrl())
+  await expect(page).toHaveURL(/\/manage\/syncdeck\/[a-z0-9-]+$/)
+  expect(page.url()).not.toContain('payload=')
+  expect(page.url()).not.toContain('sig=')
+
+  const sessionId = new URL(page.url()).pathname.split('/').at(-1)
+  expect(sessionId).toBeTruthy()
+  const recoveryCookies = (await context.cookies()).filter(
+    (cookie) => cookie.name === 'syncdeck_instructor_recoveries',
+  )
+  expect(recoveryCookies).toHaveLength(1)
+  expect(recoveryCookies[0]).toMatchObject({
+    httpOnly: true,
+    sameSite: 'Lax',
+    path: '/api/syncdeck',
+  })
+
+  const recovery = await page.evaluate(async (id) => {
+    const response = await fetch(`/api/syncdeck/${encodeURIComponent(id ?? '')}/instructor-passcode`, {
+      credentials: 'include',
+    })
+    return response.status
+  }, sessionId)
+  expect(recovery).toBe(200)
+})

--- a/activities/syncdeck/server/learnIntegration.test.ts
+++ b/activities/syncdeck/server/learnIntegration.test.ts
@@ -284,7 +284,9 @@ void test('Learn routes transition a one-time waiting-room entry into an active 
     assert.equal(reusedSubstituteLaunchResponse.redirectTo, `/manage/syncdeck/${createdSessionId}`)
     assert.ok(reusedSubstituteLaunchResponse.cookies.some((item) => item.name === 'syncdeck_instructor_recoveries'))
     assert.equal(instructorSessionCreateCount, 1)
+    assert.ok(infoLogs.some((message) => message.includes('learn-substitute-link-launched') && message.includes('"reused":true')))
 
+    console.info('[TEST] Expected substitute launch with an active mismatched deck to return a non-retryable response.')
     const mismatchedDeckSubstituteResponse = response()
     await getHandlers.get('/api/syncdeck/learn/substitute')!(
       { params: {}, query: substituteInstructorLink(resourceId, 'https://slides.example/other-deck') },
@@ -294,6 +296,7 @@ void test('Learn routes transition a one-time waiting-room entry into an active 
     assert.equal(mismatchedDeckSubstituteResponse.headers['Content-Type'], 'text/html; charset=utf-8')
     assert.match(String(mismatchedDeckSubstituteResponse.body), /Presentation URL cannot change while the instructor session is active/)
     assert.match(String(mismatchedDeckSubstituteResponse.body), /Ask the instructor who shared this link for a new one/)
+    assert.ok(infoLogs.some((message) => message.includes('learn-substitute-link-presentation-url-mismatch') && message.includes('"status":409')))
 
     console.info('[TEST] Expected invalid substitute instructor link to fail closed.')
     const invalidSubstituteResponse = response()
@@ -365,6 +368,7 @@ void test('Learn routes transition a one-time waiting-room entry into an active 
     )
     await substituteSessionStarted
     const inProgressSubstituteResponse = response()
+    console.info('[TEST] Expected a duplicate substitute launch to report the pending session start.')
     await getHandlers.get('/api/syncdeck/learn/substitute')!(
       { params: {}, query: startingSubstituteLaunch },
       inProgressSubstituteResponse,
@@ -372,7 +376,9 @@ void test('Learn routes transition a one-time waiting-room entry into an active 
     assert.equal(inProgressSubstituteResponse.statusCode, 202)
     assert.equal(inProgressSubstituteResponse.headers['Content-Type'], 'text/html; charset=utf-8')
     assert.match(String(inProgressSubstituteResponse.body), /SyncDeck session is starting/)
+    assert.ok(infoLogs.some((message) => message.includes('learn-substitute-link-start-pending') && message.includes('"status":202')))
     const contendedSubstituteResponse = response()
+    console.info('[TEST] Expected a different substitute launch to report the in-progress session start.')
     await getHandlers.get('/api/syncdeck/learn/substitute')!(
       { params: {}, query: substituteInstructorLink(startingSubstituteResourceId, 'https://slides.example/substitute-starting', 'substitute-contended') },
       contendedSubstituteResponse,
@@ -380,10 +386,30 @@ void test('Learn routes transition a one-time waiting-room entry into an active 
     assert.equal(contendedSubstituteResponse.statusCode, 409)
     assert.equal(contendedSubstituteResponse.headers['Content-Type'], 'text/html; charset=utf-8')
     assert.match(String(contendedSubstituteResponse.body), /SyncDeck session is starting/)
+    assert.ok(infoLogs.some((message) => message.includes('learn-substitute-link-start-in-progress') && message.includes('"status":409')))
     releaseDelayedSubstituteStart()
     await firstSubstituteLaunch
+    assert.ok(infoLogs.some((message) => message.includes('learn-substitute-link-launched') && message.includes('"reused":false')))
     delayedInstructorSession = null
     notifyInstructorSessionStart = null
+
+    console.info('[TEST] Expected substitute-launch cleanup failures to preserve the safe error response.')
+    const originalDeleteForSubstituteCleanup = sessions.delete.bind(sessions)
+    sessions.delete = async (id) => {
+      if (id.startsWith('learn-syncdeck-entry-')) throw new Error('test substitute cleanup failure')
+      return await originalDeleteForSubstituteCleanup(id)
+    }
+    failInstructorSessionCreation = true
+    const substituteCleanupFailureResponse = response()
+    await getHandlers.get('/api/syncdeck/learn/substitute')!(
+      { params: {}, query: substituteInstructorLink('learn-resource-substitute-cleanup', 'https://slides.example/substitute-cleanup', 'substitute-cleanup') },
+      substituteCleanupFailureResponse,
+    )
+    assert.equal(substituteCleanupFailureResponse.statusCode, 500)
+    assert.ok(errorLogs.some((message) => message.includes('learn-substitute-link-start-cleanup-failed') && message.includes('test substitute cleanup failure')))
+    assert.ok(errorLogs.some((message) => message.includes('learn-substitute-link-start-failed') && message.includes('test instructor-session creation failure')))
+    sessions.delete = originalDeleteForSubstituteCleanup
+    failInstructorSessionCreation = false
 
     const replayResponse = response()
     await postHandlers.get('/api/integrations/learn/v1/activities/:activityId/resources/:resourceLinkId/start')!(

--- a/activities/syncdeck/server/learnIntegration.test.ts
+++ b/activities/syncdeck/server/learnIntegration.test.ts
@@ -285,6 +285,15 @@ void test('Learn routes transition a one-time waiting-room entry into an active 
     assert.ok(reusedSubstituteLaunchResponse.cookies.some((item) => item.name === 'syncdeck_instructor_recoveries'))
     assert.equal(instructorSessionCreateCount, 1)
 
+    const mismatchedDeckSubstituteResponse = response()
+    await getHandlers.get('/api/syncdeck/learn/substitute')!(
+      { params: {}, query: substituteInstructorLink(resourceId, 'https://slides.example/other-deck') },
+      mismatchedDeckSubstituteResponse,
+    )
+    assert.equal(mismatchedDeckSubstituteResponse.statusCode, 409)
+    assert.equal(mismatchedDeckSubstituteResponse.headers['Content-Type'], 'text/html; charset=utf-8')
+    assert.match(String(mismatchedDeckSubstituteResponse.body), /Presentation URL cannot change while the instructor session is active/)
+
     console.info('[TEST] Expected invalid substitute instructor link to fail closed.')
     const invalidSubstituteResponse = response()
     await getHandlers.get('/api/syncdeck/learn/substitute')!(

--- a/activities/syncdeck/server/learnIntegration.test.ts
+++ b/activities/syncdeck/server/learnIntegration.test.ts
@@ -16,6 +16,7 @@ interface MockResponse {
   cookie(name: string, value: string, options: Record<string, unknown>): void
   redirect(status: number, url: string): void
   setHeader(name: string, value: string): void
+  send(body: string): void
 }
 
 interface MockRequest {
@@ -40,6 +41,7 @@ function response(): MockResponse {
     cookie(name, value, options) { this.cookies.push({ name, value, options }) },
     redirect(status, url) { this.statusCode = status; this.redirectTo = url },
     setHeader(name, value) { this.headers[name] = value },
+    send(body) { this.body = body },
   }
 }
 
@@ -128,6 +130,7 @@ void test('Learn routes transition a one-time waiting-room entry into an active 
     const sessions = store(broadcasts)
     const ws: WsRouter = { wss: { clients: new Set<ActiveBitsWebSocket>(), close() {} }, register() {} }
     let createdSessionId = ''
+    let instructorSessionCreateCount = 0
     let delayedInstructorSession: Promise<void> | null = null
     let notifyInstructorSessionStart: (() => void) | null = null
     let failInstructorSessionCreation = false
@@ -139,6 +142,7 @@ void test('Learn routes transition a one-time waiting-room entry into an active 
       sessions,
       ws,
       async createInstructorSession() {
+        instructorSessionCreateCount += 1
         notifyInstructorSessionStart?.()
         if (delayedInstructorSession) await delayedInstructorSession
         if (failInstructorSessionCreation) throw new Error('test instructor-session creation failure')
@@ -271,6 +275,16 @@ void test('Learn routes transition a one-time waiting-room entry into an active 
     assert.equal(substituteLaunchResponse.headers['Referrer-Policy'], 'no-referrer')
     assert.ok(substituteLaunchResponse.cookies.some((item) => item.name === 'syncdeck_instructor_recoveries'))
 
+    const reusedSubstituteLaunchResponse = response()
+    await getHandlers.get('/api/syncdeck/learn/substitute')!(
+      { params: {}, query: substituteLaunch },
+      reusedSubstituteLaunchResponse,
+    )
+    assert.equal(reusedSubstituteLaunchResponse.statusCode, 302)
+    assert.equal(reusedSubstituteLaunchResponse.redirectTo, `/manage/syncdeck/${createdSessionId}`)
+    assert.ok(reusedSubstituteLaunchResponse.cookies.some((item) => item.name === 'syncdeck_instructor_recoveries'))
+    assert.equal(instructorSessionCreateCount, 1)
+
     console.info('[TEST] Expected invalid substitute instructor link to fail closed.')
     const invalidSubstituteResponse = response()
     await getHandlers.get('/api/syncdeck/learn/substitute')!(
@@ -278,6 +292,8 @@ void test('Learn routes transition a one-time waiting-room entry into an active 
       invalidSubstituteResponse,
     )
     assert.equal(invalidSubstituteResponse.statusCode, 403)
+    assert.equal(invalidSubstituteResponse.headers['Content-Type'], 'text/html; charset=utf-8')
+    assert.match(String(invalidSubstituteResponse.body), /SyncDeck launch unavailable/)
 
     console.info('[TEST] Expected expired substitute instructor link to fail closed.')
     const expiredSubstituteResponse = response()
@@ -296,6 +312,21 @@ void test('Learn routes transition a one-time waiting-room entry into an active 
     assert.equal(instructorLaunchResponse.redirectTo, `/manage/syncdeck/${createdSessionId}`)
     assert.equal(instructorLaunchResponse.headers['Referrer-Policy'], 'no-referrer')
     assert.deepEqual(instructorLaunchResponse.cookies, [{ name: 'syncdeck_instructor_recoveries', value: 'recovered', options: {} }])
+
+    const activeSessionWithoutRecovery = await sessions.get(createdSessionId)
+    assert.ok(activeSessionWithoutRecovery)
+    delete activeSessionWithoutRecovery.data.instructorRecoveryToken
+    await sessions.set(createdSessionId, activeSessionWithoutRecovery)
+    console.info('[TEST] Expected substitute launch without active recovery state to fail closed.')
+    const missingRecoverySubstituteResponse = response()
+    await getHandlers.get('/api/syncdeck/learn/substitute')!(
+      { params: {}, query: substituteLaunch },
+      missingRecoverySubstituteResponse,
+    )
+    assert.equal(missingRecoverySubstituteResponse.statusCode, 500)
+    assert.equal(missingRecoverySubstituteResponse.headers['Content-Type'], 'text/html; charset=utf-8')
+    assert.match(String(missingRecoverySubstituteResponse.body), /Active instructor recovery is unavailable/)
+    assert.equal(instructorSessionCreateCount, 1)
 
     const waitStatusResponse = response()
     await getHandlers.get('/api/integrations/learn/v1/activities/:activityId/wait/status')!(

--- a/activities/syncdeck/server/learnIntegration.test.ts
+++ b/activities/syncdeck/server/learnIntegration.test.ts
@@ -365,6 +365,14 @@ void test('Learn routes transition a one-time waiting-room entry into an active 
     assert.equal(inProgressSubstituteResponse.statusCode, 202)
     assert.equal(inProgressSubstituteResponse.headers['Content-Type'], 'text/html; charset=utf-8')
     assert.match(String(inProgressSubstituteResponse.body), /SyncDeck session is starting/)
+    const contendedSubstituteResponse = response()
+    await getHandlers.get('/api/syncdeck/learn/substitute')!(
+      { params: {}, query: substituteInstructorLink(startingSubstituteResourceId, 'https://slides.example/substitute-starting', 'substitute-contended') },
+      contendedSubstituteResponse,
+    )
+    assert.equal(contendedSubstituteResponse.statusCode, 409)
+    assert.equal(contendedSubstituteResponse.headers['Content-Type'], 'text/html; charset=utf-8')
+    assert.match(String(contendedSubstituteResponse.body), /SyncDeck session is starting/)
     releaseDelayedSubstituteStart()
     await firstSubstituteLaunch
     delayedInstructorSession = null

--- a/activities/syncdeck/server/learnIntegration.test.ts
+++ b/activities/syncdeck/server/learnIntegration.test.ts
@@ -347,6 +347,13 @@ void test('Learn routes transition a one-time waiting-room entry into an active 
 
     const startingSubstituteResourceId = 'learn-resource-substitute-starting'
     const startingSubstituteLaunch = substituteInstructorLink(startingSubstituteResourceId, 'https://slides.example/substitute-starting', 'substitute-starting')
+    const startingStudentEntryPath = `/api/integrations/learn/v1/activities/syncdeck/resources/${startingSubstituteResourceId}/student-entry`
+    const startingStudentEntryResponse = response()
+    await postHandlers.get('/api/integrations/learn/v1/activities/:activityId/resources/:resourceLinkId/student-entry')!(
+      { params: { activityId: 'syncdeck', resourceLinkId: startingSubstituteResourceId }, ...signedRequest('POST', startingStudentEntryPath, {}, 'substitute-starting-student-entry') },
+      startingStudentEntryResponse,
+    )
+    assert.equal((startingStudentEntryResponse.body as { state?: unknown }).state, 'waiting')
     let releaseDelayedSubstituteStart!: () => void
     delayedInstructorSession = new Promise<void>((resolve) => { releaseDelayedSubstituteStart = resolve })
     let resolveSubstituteSessionStart!: () => void

--- a/activities/syncdeck/server/learnIntegration.test.ts
+++ b/activities/syncdeck/server/learnIntegration.test.ts
@@ -93,6 +93,15 @@ function signedRequest(method: string, path: string, body: unknown, nonce: strin
   }
 }
 
+function substituteInstructorLink(resourceLinkId: string, presentationUrl: string, jti = 'substitute-link-test', expiresAt = Date.now() + 60_000) {
+  const secret = process.env.LEARN_SYNCDECK_HMAC_SECRET!
+  const payload = Buffer.from(JSON.stringify({ expiresAt, jti, presentationUrl, provider: 'learn-test', resourceLinkId, v: 1 }), 'utf8').toString('base64url')
+  return {
+    payload,
+    sig: createHmac('sha256', secret).update(`LEARN_SYNCDECK_SUBSTITUTE_LINK\n${payload}`, 'utf8').digest('hex'),
+  }
+}
+
 void test('buildLearnHmacCanonicalRequest orders object keys by codepoint', () => {
   const request = buildLearnHmacCanonicalRequest('POST', '/path', '123', 'nonce', 'provider', { ä: 'umlaut', z: 'zee' })
   const expectedHash = createHash('sha256').update('{"z":"zee","ä":"umlaut"}', 'utf8').digest('hex')
@@ -250,6 +259,33 @@ void test('Learn routes transition a one-time waiting-room entry into an active 
     notifyInstructorSessionStart = null
     assert.equal(startResponse.statusCode, 200)
     assert.equal((startResponse.body as { activeSessionId?: unknown }).activeSessionId, createdSessionId)
+
+    const substituteLaunch = substituteInstructorLink(resourceId, 'https://slides.example/deck')
+    const substituteLaunchResponse = response()
+    await getHandlers.get('/api/syncdeck/learn/substitute')!(
+      { params: {}, query: substituteLaunch },
+      substituteLaunchResponse,
+    )
+    assert.equal(substituteLaunchResponse.statusCode, 302)
+    assert.equal(substituteLaunchResponse.redirectTo, `/manage/syncdeck/${createdSessionId}`)
+    assert.equal(substituteLaunchResponse.headers['Referrer-Policy'], 'no-referrer')
+    assert.ok(substituteLaunchResponse.cookies.some((item) => item.name === 'syncdeck_instructor_recoveries'))
+
+    console.info('[TEST] Expected invalid substitute instructor link to fail closed.')
+    const invalidSubstituteResponse = response()
+    await getHandlers.get('/api/syncdeck/learn/substitute')!(
+      { params: {}, query: { payload: substituteLaunch.payload, sig: '0'.repeat(64) } },
+      invalidSubstituteResponse,
+    )
+    assert.equal(invalidSubstituteResponse.statusCode, 403)
+
+    console.info('[TEST] Expected expired substitute instructor link to fail closed.')
+    const expiredSubstituteResponse = response()
+    await getHandlers.get('/api/syncdeck/learn/substitute')!(
+      { params: {}, query: substituteInstructorLink(resourceId, 'https://slides.example/deck', 'expired-substitute-link', Date.now() - 1) },
+      expiredSubstituteResponse,
+    )
+    assert.equal(expiredSubstituteResponse.statusCode, 403)
 
     const instructorLaunchUrl = new URL(String((startResponse.body as { instructorLaunchUrl: string }).instructorLaunchUrl), 'https://bits.example')
     const instructorLaunchResponse = response()

--- a/activities/syncdeck/server/learnIntegration.test.ts
+++ b/activities/syncdeck/server/learnIntegration.test.ts
@@ -344,6 +344,31 @@ void test('Learn routes transition a one-time waiting-room entry into an active 
     )
     assert.deepEqual(waitStatusResponse.body, { state: 'active', studentLaunchUrl: '/syncdeck-live' })
 
+    const startingSubstituteResourceId = 'learn-resource-substitute-starting'
+    const startingSubstituteLaunch = substituteInstructorLink(startingSubstituteResourceId, 'https://slides.example/substitute-starting', 'substitute-starting')
+    let releaseDelayedSubstituteStart!: () => void
+    delayedInstructorSession = new Promise<void>((resolve) => { releaseDelayedSubstituteStart = resolve })
+    let resolveSubstituteSessionStart!: () => void
+    const substituteSessionStarted = new Promise<void>((resolve) => { resolveSubstituteSessionStart = resolve })
+    notifyInstructorSessionStart = resolveSubstituteSessionStart
+    const firstSubstituteLaunch = getHandlers.get('/api/syncdeck/learn/substitute')!(
+      { params: {}, query: startingSubstituteLaunch },
+      response(),
+    )
+    await substituteSessionStarted
+    const inProgressSubstituteResponse = response()
+    await getHandlers.get('/api/syncdeck/learn/substitute')!(
+      { params: {}, query: startingSubstituteLaunch },
+      inProgressSubstituteResponse,
+    )
+    assert.equal(inProgressSubstituteResponse.statusCode, 202)
+    assert.equal(inProgressSubstituteResponse.headers['Content-Type'], 'text/html; charset=utf-8')
+    assert.match(String(inProgressSubstituteResponse.body), /SyncDeck session is starting/)
+    releaseDelayedSubstituteStart()
+    await firstSubstituteLaunch
+    delayedInstructorSession = null
+    notifyInstructorSessionStart = null
+
     const replayResponse = response()
     await postHandlers.get('/api/integrations/learn/v1/activities/:activityId/resources/:resourceLinkId/start')!(
       { params: { activityId: 'syncdeck', resourceLinkId: resourceId }, ...signedRequest('POST', startPath, { presentationUrl: 'https://slides.example/deck', requestId: 'start-1' }, 'start-nonce') },

--- a/activities/syncdeck/server/learnIntegration.test.ts
+++ b/activities/syncdeck/server/learnIntegration.test.ts
@@ -293,6 +293,7 @@ void test('Learn routes transition a one-time waiting-room entry into an active 
     assert.equal(mismatchedDeckSubstituteResponse.statusCode, 409)
     assert.equal(mismatchedDeckSubstituteResponse.headers['Content-Type'], 'text/html; charset=utf-8')
     assert.match(String(mismatchedDeckSubstituteResponse.body), /Presentation URL cannot change while the instructor session is active/)
+    assert.match(String(mismatchedDeckSubstituteResponse.body), /Ask the instructor who shared this link for a new one/)
 
     console.info('[TEST] Expected invalid substitute instructor link to fail closed.')
     const invalidSubstituteResponse = response()

--- a/activities/syncdeck/server/learnIntegration.ts
+++ b/activities/syncdeck/server/learnIntegration.ts
@@ -356,7 +356,7 @@ function setNoStore(res: RouteResponse): void {
 }
 
 function substituteLaunchErrorPage(status: number, message: string, retryable: boolean): string {
-  const isStarting = status === 202
+  const isStarting = status === 202 || (status === 409 && retryable)
   const title = isStarting ? 'SyncDeck session is starting' : 'SyncDeck launch unavailable'
   const retryHint = retryable
     ? '<p>Please wait a moment and refresh this page.</p>'

--- a/activities/syncdeck/server/learnIntegration.ts
+++ b/activities/syncdeck/server/learnIntegration.ts
@@ -699,7 +699,7 @@ export function registerLearnSyncDeckRoutes(options: LearnSyncDeckRouteOptions):
       let recoveryToken: string | null = null
       if (entry?.data.state === 'active' && entry.data.activeSessionId) {
         if (entry.data.presentationUrl !== link.presentationUrl) {
-          return void res.status(409).json({ error: 'Presentation URL cannot change while the instructor session is active' })
+          return void respondToSubstituteLaunchError(res, 409, 'Presentation URL cannot change while the instructor session is active')
         }
         const activeSession = await sessions.get(entry.data.activeSessionId)
         if (activeSession) {

--- a/activities/syncdeck/server/learnIntegration.ts
+++ b/activities/syncdeck/server/learnIntegration.ts
@@ -6,6 +6,8 @@ import type { ActiveBitsWebSocket, WsRouter } from '../../../types/websocket.js'
 const INTEGRATION_PREFIX = '/api/integrations/learn/v1'
 const BROWSER_PREFIX = '/integrations/learn'
 const INSTRUCTOR_HANDOFF_PREFIX = '/api/syncdeck/learn'
+const SUBSTITUTE_INSTRUCTOR_PREFIX = '/api/syncdeck/learn/substitute'
+const SUBSTITUTE_LINK_CONTEXT = 'LEARN_SYNCDECK_SUBSTITUTE_LINK'
 const ACTIVITY_ID = 'syncdeck'
 const HMAC_SIGNATURE_HEADER = 'x-learn-signature'
 const HMAC_KEY_ID_HEADER = 'x-learn-key-id'
@@ -66,6 +68,15 @@ interface BrowserTokenData extends Record<string, unknown> {
   expiresAt: number
 }
 
+interface SubstituteInstructorLinkPayload {
+  v: 1
+  provider: string
+  resourceLinkId: string
+  presentationUrl: string
+  expiresAt: number
+  jti: string
+}
+
 export interface LearnSyncDeckRouteOptions {
   app: RouteApp
   sessions: SessionStore
@@ -122,6 +133,28 @@ function sameSecret(left: string, right: string): boolean {
   const leftBytes = Buffer.from(left, 'utf8')
   const rightBytes = Buffer.from(right, 'utf8')
   return leftBytes.length === rightBytes.length && timingSafeEqual(leftBytes, rightBytes)
+}
+
+function readSubstituteInstructorLink(payloadValue: unknown, signature: unknown, secret: string): SubstituteInstructorLinkPayload | null {
+  const payload = readString(payloadValue, 8192)
+  const signatureValue = readString(signature, 128)
+  if (!payload || !signatureValue || !/^[A-Za-z0-9_-]+$/.test(payload) || !/^[a-f0-9]{64}$/i.test(signatureValue)) return null
+  const expected = createHmac('sha256', secret).update(`${SUBSTITUTE_LINK_CONTEXT}\n${payload}`, 'utf8').digest('hex')
+  if (!sameSecret(expected, signatureValue.toLowerCase())) return null
+  try {
+    const decoded = Buffer.from(payload, 'base64url').toString('utf8')
+    const parsed = JSON.parse(decoded) as Record<string, unknown>
+    if (Buffer.from(stableJson(parsed), 'utf8').toString('base64url') !== payload) return null
+    const provider = readString(parsed.provider, MAX_PROVIDER_LENGTH)
+    const resourceLinkId = readString(parsed.resourceLinkId, MAX_RESOURCE_ID_LENGTH)
+    const presentationUrl = readString(parsed.presentationUrl, 4096)
+    const jti = readString(parsed.jti, 256)
+    const expiresAt = typeof parsed.expiresAt === 'number' && Number.isFinite(parsed.expiresAt) ? parsed.expiresAt : 0
+    if (parsed.v !== 1 || !provider || !resourceLinkId || !presentationUrl || !isValidHttpUrl(presentationUrl) || !jti || expiresAt <= Date.now()) return null
+    return { v: 1, provider, resourceLinkId, presentationUrl, expiresAt, jti }
+  } catch {
+    return null
+  }
 }
 
 type NonceClaimResult = 'claimed' | 'duplicate' | 'unavailable'
@@ -617,6 +650,75 @@ export function registerLearnSyncDeckRoutes(options: LearnSyncDeckRouteOptions):
     await sessions.delete(id)
     console.info(JSON.stringify({ activity: 'syncdeck', event: 'learn-instructor-session-stopped', resourceLinkId, sessionId }))
     res.json({ state: 'inactive', alreadyInactive: false })
+  })
+
+  app.get(SUBSTITUTE_INSTRUCTOR_PREFIX, async (req, res) => {
+    setNoStore(res)
+    res.setHeader?.('Referrer-Policy', 'no-referrer')
+    const key = configuredKey()
+    const link = key ? readSubstituteInstructorLink(req.query?.payload, req.query?.sig, key.secret) : null
+    if (!key || !link) {
+      console.info(JSON.stringify({ activity: ACTIVITY_ID, event: 'learn-substitute-link-rejected' }))
+      return void res.status(403).json({ error: 'Invalid or expired substitute instructor link' })
+    }
+    const id = mappingId(key.secret, ACTIVITY_ID, link.provider, link.resourceLinkId)
+    const startLock = await claimStartLock(sessions, id)
+    if (startLock.state !== 'acquired') {
+      const status = startLock.state === 'unavailable' ? 503 : 409
+      return void res.status(status).json({ error: status === 503 ? 'Learn session coordination is unavailable' : 'A substitute instructor launch is already in progress; retry shortly' })
+    }
+    try {
+      let entry = await loadEntry(id)
+      let sessionId: string | null = null
+      let recoveryToken: string | null = null
+      if (entry?.data.state === 'active' && entry.data.activeSessionId) {
+        if (entry.data.presentationUrl !== link.presentationUrl) {
+          return void res.status(409).json({ error: 'Presentation URL cannot change while the instructor session is active' })
+        }
+        const activeSession = await sessions.get(entry.data.activeSessionId)
+        if (activeSession) {
+          sessionId = entry.data.activeSessionId
+          recoveryToken = typeof activeSession.data.instructorRecoveryToken === 'string' ? activeSession.data.instructorRecoveryToken : null
+        } else {
+          await sessions.delete(id)
+          entry = null
+        }
+      }
+      if (!sessionId || !recoveryToken) {
+        const previousData = entry?.data
+        try {
+          if (!entry) {
+            const createdEntry = await createSession(sessions, { data: { learnIntegrationKind: 'entry', activityId: ACTIVITY_ID, provider: link.provider, resourceLinkId: link.resourceLinkId, state: 'waiting', startRequestId: `substitute:${link.jti}`, activeSessionId: null, presentationUrl: null, expiresAt: Date.now() + WAITING_TTL_MS } })
+            const generatedId = createdEntry.id
+            createdEntry.id = id
+            createdEntry.type = 'syncdeck-learn-entry'
+            await sessions.delete(generatedId)
+            await sessions.set(id, createdEntry, WAITING_TTL_MS)
+            entry = { session: createdEntry, data: getEntryData(createdEntry)! }
+          }
+          const created = await options.createInstructorSession(link.presentationUrl)
+          sessionId = created.sessionId
+          recoveryToken = created.instructorRecoveryToken
+          entry.session.data = { learnIntegrationKind: 'entry', activityId: ACTIVITY_ID, provider: link.provider, resourceLinkId: link.resourceLinkId, state: 'active', startRequestId: `substitute:${link.jti}`, activeSessionId: sessionId, presentationUrl: link.presentationUrl, expiresAt: Date.now() + (sessions.ttlMs ?? WAITING_TTL_MS) }
+          await sessions.set(id, entry.session)
+        } catch (error) {
+          if (previousData && entry) {
+            entry.session.data = previousData
+            await sessions.set(id, entry.session)
+          } else {
+            await sessions.delete(id)
+          }
+          console.error(JSON.stringify({ activity: ACTIVITY_ID, event: 'learn-substitute-link-start-failed', jti: link.jti, error: error instanceof Error ? error.message : String(error) }))
+          return void res.status(500).json({ error: 'Unable to start the substitute instructor session' })
+        }
+      }
+      options.writeInstructorRecoveryCookie(req, res, sessionId, recoveryToken)
+      console.info(JSON.stringify({ activity: ACTIVITY_ID, event: 'learn-substitute-link-launched', jti: link.jti, sessionId }))
+      if (typeof res.redirect === 'function') return void res.redirect(302, `/manage/syncdeck/${encodeURIComponent(sessionId)}`)
+      res.status(302).json({ redirectTo: `/manage/syncdeck/${encodeURIComponent(sessionId)}` })
+    } finally {
+      await startLock.release()
+    }
   })
 
   app.get(`${BROWSER_PREFIX}/:activityId/wait/:tokenId`, async (req, res) => {

--- a/activities/syncdeck/server/learnIntegration.ts
+++ b/activities/syncdeck/server/learnIntegration.ts
@@ -727,6 +727,9 @@ export function registerLearnSyncDeckRoutes(options: LearnSyncDeckRouteOptions):
             await sessions.delete(generatedId)
             await sessions.set(id, createdEntry, WAITING_TTL_MS)
             entry = { session: createdEntry, data: getEntryData(createdEntry)! }
+          } else {
+            entry.session.data = { ...entry.data, startRequestId: `substitute:${link.jti}` }
+            await sessions.set(id, entry.session)
           }
           const created = await options.createInstructorSession(link.presentationUrl)
           sessionId = created.sessionId

--- a/activities/syncdeck/server/learnIntegration.ts
+++ b/activities/syncdeck/server/learnIntegration.ts
@@ -356,10 +356,12 @@ function setNoStore(res: RouteResponse): void {
 }
 
 function substituteLaunchErrorPage(status: number, message: string): string {
+  const isStarting = status === 202
+  const title = isStarting ? 'SyncDeck session is starting' : 'SyncDeck launch unavailable'
   const retryHint = status === 202 || status === 409 || status === 503
     ? '<p>Please wait a moment and refresh this page.</p>'
     : '<p>Ask the instructor who shared this link for a new one.</p>'
-  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="referrer" content="no-referrer"><title>SyncDeck launch unavailable</title></head><body><main><h1>SyncDeck launch unavailable</h1><p>${message}</p>${retryHint}</main></body></html>`
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="referrer" content="no-referrer"><title>${title}</title></head><body><main><h1>${title}</h1><p>${message}</p>${retryHint}</main></body></html>`
 }
 
 function respondToSubstituteLaunchError(res: RouteResponse, status: number, message: string): void {

--- a/activities/syncdeck/server/learnIntegration.ts
+++ b/activities/syncdeck/server/learnIntegration.ts
@@ -37,6 +37,7 @@ interface RouteRequest {
 interface RouteResponse {
   status(code: number): RouteResponse
   json(payload: unknown): void
+  send?(body: string): void
   cookie?(name: string, value: string, options: Record<string, unknown>): void
   redirect?(status: number, url: string): void
   setHeader?(name: string, value: string): void
@@ -354,6 +355,23 @@ function setNoStore(res: RouteResponse): void {
   res.setHeader?.('Cache-Control', 'no-store')
 }
 
+function substituteLaunchErrorPage(status: number, message: string): string {
+  const retryHint = status === 202 || status === 409 || status === 503
+    ? '<p>Please wait a moment and refresh this page.</p>'
+    : '<p>Ask the instructor who shared this link for a new one.</p>'
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="referrer" content="no-referrer"><title>SyncDeck launch unavailable</title></head><body><main><h1>SyncDeck launch unavailable</h1><p>${message}</p>${retryHint}</main></body></html>`
+}
+
+function respondToSubstituteLaunchError(res: RouteResponse, status: number, message: string): void {
+  if (typeof res.send === 'function') {
+    res.setHeader?.('Content-Type', 'text/html; charset=utf-8')
+    res.status(status)
+    res.send(substituteLaunchErrorPage(status, message))
+    return
+  }
+  res.status(status).json({ error: message })
+}
+
 function logLearnRequestFailure(route: string, reason: string, context: Record<string, unknown> = {}): void {
   console.info(JSON.stringify({ activity: ACTIVITY_ID, event: 'learn-integration-request-failed', route, reason, ...context }))
 }
@@ -659,13 +677,21 @@ export function registerLearnSyncDeckRoutes(options: LearnSyncDeckRouteOptions):
     const link = key ? readSubstituteInstructorLink(req.query?.payload, req.query?.sig, key.secret) : null
     if (!key || !link) {
       console.info(JSON.stringify({ activity: ACTIVITY_ID, event: 'learn-substitute-link-rejected' }))
-      return void res.status(403).json({ error: 'Invalid or expired substitute instructor link' })
+      return void respondToSubstituteLaunchError(res, 403, 'Invalid or expired substitute instructor link')
     }
     const id = mappingId(key.secret, ACTIVITY_ID, link.provider, link.resourceLinkId)
     const startLock = await claimStartLock(sessions, id)
     if (startLock.state !== 'acquired') {
-      const status = startLock.state === 'unavailable' ? 503 : 409
-      return void res.status(status).json({ error: status === 503 ? 'Learn session coordination is unavailable' : 'A substitute instructor launch is already in progress; retry shortly' })
+      if (startLock.state === 'locked') {
+        const pendingEntry = await loadEntry(id)
+        if (pendingEntry?.data.startRequestId === `substitute:${link.jti}`) {
+          return void respondToSubstituteLaunchError(res, 202, 'Your substitute instructor session is starting')
+        }
+      }
+      const [status, message] = startLock.state === 'unavailable'
+        ? [503, 'Learn session coordination is unavailable'] as const
+        : [409, 'A substitute instructor launch is already in progress'] as const
+      return void respondToSubstituteLaunchError(res, status, message)
     }
     try {
       let entry = await loadEntry(id)
@@ -679,6 +705,10 @@ export function registerLearnSyncDeckRoutes(options: LearnSyncDeckRouteOptions):
         if (activeSession) {
           sessionId = entry.data.activeSessionId
           recoveryToken = typeof activeSession.data.instructorRecoveryToken === 'string' ? activeSession.data.instructorRecoveryToken : null
+          if (!recoveryToken) {
+            console.error(JSON.stringify({ activity: ACTIVITY_ID, event: 'learn-substitute-link-recovery-unavailable', jti: link.jti, sessionId }))
+            return void respondToSubstituteLaunchError(res, 500, 'Active instructor recovery is unavailable')
+          }
         } else {
           await sessions.delete(id)
           entry = null
@@ -709,7 +739,7 @@ export function registerLearnSyncDeckRoutes(options: LearnSyncDeckRouteOptions):
             await sessions.delete(id)
           }
           console.error(JSON.stringify({ activity: ACTIVITY_ID, event: 'learn-substitute-link-start-failed', jti: link.jti, error: error instanceof Error ? error.message : String(error) }))
-          return void res.status(500).json({ error: 'Unable to start the substitute instructor session' })
+          return void respondToSubstituteLaunchError(res, 500, 'Unable to start the substitute instructor session')
         }
       }
       options.writeInstructorRecoveryCookie(req, res, sessionId, recoveryToken)

--- a/activities/syncdeck/server/learnIntegration.ts
+++ b/activities/syncdeck/server/learnIntegration.ts
@@ -355,20 +355,20 @@ function setNoStore(res: RouteResponse): void {
   res.setHeader?.('Cache-Control', 'no-store')
 }
 
-function substituteLaunchErrorPage(status: number, message: string): string {
+function substituteLaunchErrorPage(status: number, message: string, retryable: boolean): string {
   const isStarting = status === 202
   const title = isStarting ? 'SyncDeck session is starting' : 'SyncDeck launch unavailable'
-  const retryHint = status === 202 || status === 409 || status === 503
+  const retryHint = retryable
     ? '<p>Please wait a moment and refresh this page.</p>'
     : '<p>Ask the instructor who shared this link for a new one.</p>'
   return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="referrer" content="no-referrer"><title>${title}</title></head><body><main><h1>${title}</h1><p>${message}</p>${retryHint}</main></body></html>`
 }
 
-function respondToSubstituteLaunchError(res: RouteResponse, status: number, message: string): void {
+function respondToSubstituteLaunchError(res: RouteResponse, status: number, message: string, retryable = status === 202 || status === 409 || status === 503): void {
   if (typeof res.send === 'function') {
     res.setHeader?.('Content-Type', 'text/html; charset=utf-8')
     res.status(status)
-    res.send(substituteLaunchErrorPage(status, message))
+    res.send(substituteLaunchErrorPage(status, message, retryable))
     return
   }
   res.status(status).json({ error: message })
@@ -701,7 +701,7 @@ export function registerLearnSyncDeckRoutes(options: LearnSyncDeckRouteOptions):
       let recoveryToken: string | null = null
       if (entry?.data.state === 'active' && entry.data.activeSessionId) {
         if (entry.data.presentationUrl !== link.presentationUrl) {
-          return void respondToSubstituteLaunchError(res, 409, 'Presentation URL cannot change while the instructor session is active')
+          return void respondToSubstituteLaunchError(res, 409, 'Presentation URL cannot change while the instructor session is active', false)
         }
         const activeSession = await sessions.get(entry.data.activeSessionId)
         if (activeSession) {

--- a/activities/syncdeck/server/learnIntegration.ts
+++ b/activities/syncdeck/server/learnIntegration.ts
@@ -684,11 +684,16 @@ export function registerLearnSyncDeckRoutes(options: LearnSyncDeckRouteOptions):
     const id = mappingId(key.secret, ACTIVITY_ID, link.provider, link.resourceLinkId)
     const startLock = await claimStartLock(sessions, id)
     if (startLock.state !== 'acquired') {
+      if (startLock.state === 'unavailable') {
+        console.error(JSON.stringify({ activity: ACTIVITY_ID, event: 'learn-substitute-link-start-lock-unavailable', resourceLinkId: link.resourceLinkId, jti: link.jti, status: 503 }))
+      }
       if (startLock.state === 'locked') {
         const pendingEntry = await loadEntry(id)
         if (pendingEntry?.data.startRequestId === `substitute:${link.jti}`) {
+          console.info(JSON.stringify({ activity: ACTIVITY_ID, event: 'learn-substitute-link-start-pending', resourceLinkId: link.resourceLinkId, jti: link.jti, status: 202 }))
           return void respondToSubstituteLaunchError(res, 202, 'Your substitute instructor session is starting')
         }
+        console.info(JSON.stringify({ activity: ACTIVITY_ID, event: 'learn-substitute-link-start-in-progress', resourceLinkId: link.resourceLinkId, jti: link.jti, status: 409 }))
       }
       const [status, message] = startLock.state === 'unavailable'
         ? [503, 'Learn session coordination is unavailable'] as const
@@ -699,8 +704,10 @@ export function registerLearnSyncDeckRoutes(options: LearnSyncDeckRouteOptions):
       let entry = await loadEntry(id)
       let sessionId: string | null = null
       let recoveryToken: string | null = null
+      let reused = false
       if (entry?.data.state === 'active' && entry.data.activeSessionId) {
         if (entry.data.presentationUrl !== link.presentationUrl) {
+          console.info(JSON.stringify({ activity: ACTIVITY_ID, event: 'learn-substitute-link-presentation-url-mismatch', resourceLinkId: link.resourceLinkId, jti: link.jti, sessionId: entry.data.activeSessionId, status: 409 }))
           return void respondToSubstituteLaunchError(res, 409, 'Presentation URL cannot change while the instructor session is active', false)
         }
         const activeSession = await sessions.get(entry.data.activeSessionId)
@@ -711,6 +718,7 @@ export function registerLearnSyncDeckRoutes(options: LearnSyncDeckRouteOptions):
             console.error(JSON.stringify({ activity: ACTIVITY_ID, event: 'learn-substitute-link-recovery-unavailable', jti: link.jti, sessionId }))
             return void respondToSubstituteLaunchError(res, 500, 'Active instructor recovery is unavailable')
           }
+          reused = true
         } else {
           await sessions.delete(id)
           entry = null
@@ -737,18 +745,22 @@ export function registerLearnSyncDeckRoutes(options: LearnSyncDeckRouteOptions):
           entry.session.data = { learnIntegrationKind: 'entry', activityId: ACTIVITY_ID, provider: link.provider, resourceLinkId: link.resourceLinkId, state: 'active', startRequestId: `substitute:${link.jti}`, activeSessionId: sessionId, presentationUrl: link.presentationUrl, expiresAt: Date.now() + (sessions.ttlMs ?? WAITING_TTL_MS) }
           await sessions.set(id, entry.session)
         } catch (error) {
-          if (previousData && entry) {
-            entry.session.data = previousData
-            await sessions.set(id, entry.session)
-          } else {
-            await sessions.delete(id)
+          try {
+            if (previousData && entry) {
+              entry.session.data = previousData
+              await sessions.set(id, entry.session)
+            } else {
+              await sessions.delete(id)
+            }
+          } catch (cleanupError) {
+            console.error(JSON.stringify({ activity: ACTIVITY_ID, event: 'learn-substitute-link-start-cleanup-failed', resourceLinkId: link.resourceLinkId, jti: link.jti, error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError) }))
           }
           console.error(JSON.stringify({ activity: ACTIVITY_ID, event: 'learn-substitute-link-start-failed', jti: link.jti, error: error instanceof Error ? error.message : String(error) }))
           return void respondToSubstituteLaunchError(res, 500, 'Unable to start the substitute instructor session')
         }
       }
       options.writeInstructorRecoveryCookie(req, res, sessionId, recoveryToken)
-      console.info(JSON.stringify({ activity: ACTIVITY_ID, event: 'learn-substitute-link-launched', jti: link.jti, sessionId }))
+      console.info(JSON.stringify({ activity: ACTIVITY_ID, event: 'learn-substitute-link-launched', resourceLinkId: link.resourceLinkId, jti: link.jti, sessionId, reused }))
       if (typeof res.redirect === 'function') return void res.redirect(302, `/manage/syncdeck/${encodeURIComponent(sessionId)}`)
       res.status(302).json({ redirectTo: `/manage/syncdeck/${encodeURIComponent(sessionId)}` })
     } finally {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,6 +10,12 @@ const serverPort =
 const persistentSessionSecret =
   process.env.PLAYWRIGHT_PERSISTENT_SESSION_SECRET ??
   randomBytes(32).toString('hex')
+const learnSyncdeckHmacSecret =
+  process.env.PLAYWRIGHT_LEARN_SYNCDECK_HMAC_SECRET ??
+  randomBytes(32).toString('hex')
+// Keep the test worker and the spawned server on the same ephemeral integration
+// key; production configuration is supplied exclusively through its environment.
+process.env.PLAYWRIGHT_LEARN_SYNCDECK_HMAC_SECRET = learnSyncdeckHmacSecret
 const shouldReuseClientBuild =
   isCi || process.env.PLAYWRIGHT_REUSE_CLIENT_DIST === '1'
 const webServerCommand = shouldReuseClientBuild
@@ -40,6 +46,8 @@ export default defineConfig({
       NODE_ENV: 'production',
       PORT: serverPort,
       PERSISTENT_SESSION_SECRET: persistentSessionSecret,
+      LEARN_SYNCDECK_HMAC_SECRET: learnSyncdeckHmacSecret,
+      LEARN_SYNCDECK_HMAC_KEY_ID: 'playwright-learn',
     },
     url: baseURL,
     reuseExistingServer: !isCi,


### PR DESCRIPTION
## Summary

Adds direct, signed substitute-instructor links for the Learn–SyncDeck integration. ActiveBits validates the time-bounded capability, starts or reuses the mapped instructor session, creates the existing httpOnly recovery handoff, and redirects to a token-free manager URL.

## Why

Allows a substitute without LMS access to open or reuse an instructor-led SyncDeck session directly in ActiveBits while students continue joining through Learn/LTI.

## Scope

- SyncDeck server route and signed-payload validation
- Recovery-cookie manager handoff and browser-friendly launch errors
- Focused integration and Chromium browser coverage
- Playwright HMAC test configuration plus implementation/security/deployment documentation

## Validation

- `npm run test:activities:file -- syncdeck/server/learnIntegration.test.ts`
- `npm --workspace activities run typecheck`
- Scoped ESLint for changed SyncDeck server/tests
- `npm run test:e2e -- --project=chromium activities/syncdeck/playwright/substitute-instructor-link.spec.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for time-limited, signed substitute-instructor links that launch or resume SyncDeck instructor sessions without LMS access.
  * Links redirect to the standard manager view and remove sensitive link parameters from the final URL.
  * Added session recovery support for substitute instructors, including secure browser-based recovery state.

* **Bug Fixes**
  * Invalid, expired, mismatched, or unavailable links now fail safely with clear error responses.
  * Added handling for sessions that are still starting or already in use.

* **Documentation**
  * Documented setup, security considerations, expiration requirements, and logging guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->