### PR TITLE
Warn before ending an undownloaded SyncDeck report

### DIFF
--- a/.agent/knowledge/repo_discoveries.md
+++ b/.agent/knowledge/repo_discoveries.md
@@ -14,6 +14,14 @@ Use this log for durable findings that future contributors and agents should reu
 
 ## Discoveries
 
+- Date: 2026-07-27
+- Area: client | activities | syncdeck | reporting
+- Discovery: SyncDeck's end-session confirmation can only know that the browser successfully initiated a report download in the active manager view; browsers do not expose a reliable signal that a user retained the downloaded file.
+- Why it matters: The irreversible-session warning should clear only after the report endpoint succeeds and the download link has been clicked. A failed request must keep the warning in place.
+- Evidence: `activities/syncdeck/client/manager/SyncDeckManager.tsx`; `activities/syncdeck/client/manager/SyncDeckManager.test.tsx`.
+- Follow-up action: If this acknowledgement must survive reloads or be shared across instructors, add an authenticated server-side report-export audit field rather than storing instructor credentials or sensitive state in browser storage.
+- Owner: Codex
+
 - Date: 2026-07-23
 - Area: server | persistent sessions | instructor recovery
 - Discovery: The shared `persistent_sessions` httpOnly cookie contains remembered teacher codes and permalink state. A fixed entry-count cap alone can exceed browser cookie limits when several SyncDeck entries carry presentation URLs; browsers may silently reject the oversized replacement cookie. Bounds must measure the percent-encoded JSON cookie value and skip individually oversized entries without evicting older valid remembered sessions.

--- a/.agent/knowledge/testing-patterns.md
+++ b/.agent/knowledge/testing-patterns.md
@@ -15,6 +15,15 @@ Capture reusable test setup patterns, common failure modes, and reliability guid
 
 ## Entries
 
+- Date: 2026-07-27
+- Scope: typecheck | activities
+- Pattern: Run the activities TypeScript check one activity directory at a time through `scripts/typecheck-activities.mjs`. The runner reuses `activities/tsconfig.json` compiler options and shared contracts, but narrows source inclusion to the current activity.
+- Why it helps: Isolated typechecks identify the failing activity and reduce peak compiler memory while retaining the activity's normal type boundary.
+- Example (file/path): `scripts/typecheck-activities.mjs`; `activities/package.json`
+- Failure signal: A workspace-wide `tsc --noEmit` is killed or reports errors without identifying the smallest activity scope.
+- Follow-up action: Keep this runner's activity discovery aligned with `scripts/lint-activities.mjs` when adding a new excluded directory.
+- Owner: Codex
+
 - Date: 2026-07-26
 - Scope: unit | e2e | MobCode Python runner
 - Pattern: When wrapping user Python in a function, treat blank and comment-only source as an empty suite and emit `pass`; test both source shapes in the real Brython popup as well as the source builder.

--- a/.agent/knowledge/testing-patterns.md
+++ b/.agent/knowledge/testing-patterns.md
@@ -16,6 +16,15 @@ Capture reusable test setup patterns, common failure modes, and reliability guid
 ## Entries
 
 - Date: 2026-07-27
+- Scope: e2e | MobCode Python runner | WebKit
+- Pattern: Use the runner suite's 15-second completion window when asserting the terminal popup reaches its `Done` state, including blank and comment-only source files.
+- Why it helps: WebKit can finish Brython worker initialization after Playwright's default five-second assertion timeout even though the popup and terminal have loaded correctly.
+- Example (file/path): `activities/mobcode/playwright/runner.spec.ts`
+- Failure signal: The popup accessibility tree still shows `Stop Python runner` and `[Python] Running test.py`, while `Close Python runner` is absent after five seconds.
+- Follow-up action: Keep the terminal-running assertion as the popup readiness check and use the longer timeout only for actual execution completion.
+- Owner: Codex
+
+- Date: 2026-07-27
 - Scope: typecheck | activities
 - Pattern: Run the activities TypeScript check one activity directory at a time through `scripts/typecheck-activities.mjs`. The runner reuses `activities/tsconfig.json` compiler options and shared contracts, but narrows source inclusion to the current activity.
 - Why it helps: Isolated typechecks identify the failing activity and reduce peak compiler memory while retaining the activity's normal type boundary.

--- a/activities/mobcode/playwright/runner.spec.ts
+++ b/activities/mobcode/playwright/runner.spec.ts
@@ -117,7 +117,7 @@ test('MobCode Python runner completes blank and comment-only files', async ({ pa
 
     const popup = await runMobCodePopup(page)
     const terminal = popup.locator('#terminal')
-    await expect(popup.getByRole('button', { name: 'Close Python runner' })).toHaveText('Done')
+    await expect(popup.getByRole('button', { name: 'Close Python runner' })).toHaveText('Done', { timeout: 15_000 })
     await expect(terminal).not.toContainText('IndentationError')
     await clickRunnerDoneAndWaitForClose(popup)
   }

--- a/activities/package.json
+++ b/activities/package.json
@@ -10,7 +10,7 @@
     "test:scope": "sh -c 'set -e; target=\"${npm_config_target:-.}\"; target=\"${target#./}\"; target=\"${target#activities/}\"; files=$(find \"$target\" -path \"*/node_modules/*\" -prune -o \\( -name \"*.test.ts\" -o -name \"*.test.tsx\" \\) -print); if [ -z \"$files\" ]; then echo \"No tests found under $target\"; exit 0; fi; node --import tsx --test --test-concurrency=\"${ACTIVITY_TEST_CONCURRENCY:-4}\" --import ../scripts/jsx-loader-register.mjs $files'",
     "test:activity": "sh -c 'set -e; activity=\"${npm_config_activity:?set --activity=<activity-folder>}\"; activity=\"${activity#./}\"; activity=\"${activity#activities/}\"; files=$(find \"$activity\" -path \"*/node_modules/*\" -prune -o \\( -name \"*.test.ts\" -o -name \"*.test.tsx\" \\) -print); if [ -z \"$files\" ]; then echo \"No tests found under $activity\"; exit 0; fi; node --import tsx --test --test-concurrency=\"${ACTIVITY_TEST_CONCURRENCY:-4}\" --import ../scripts/jsx-loader-register.mjs $files'",
     "test": "sh -c 'set -e; files=$(find . -path \"./node_modules\" -prune -o \\( -name \"*.test.ts\" -o -name \"*.test.tsx\" \\) -print); if [ -z \"$files\" ]; then echo \"No activities tests found\"; exit 0; fi; node --import tsx --test --test-concurrency=\"${ACTIVITY_TEST_CONCURRENCY:-4}\" --import ../scripts/jsx-loader-register.mjs $files'",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "node ../scripts/typecheck-activities.mjs"
   },
   "engines": {
     "node": ">=24 <25"

--- a/activities/syncdeck/client/manager/SyncDeckManager.test.tsx
+++ b/activities/syncdeck/client/manager/SyncDeckManager.test.tsx
@@ -72,6 +72,8 @@ import { buildReportContributionMap } from './SyncDeckManager.js'
 import { resolveReportContributionLabel } from './SyncDeckManager.js'
 import { buildReportPreviewSummary } from './SyncDeckManager.js'
 import { buildEndSessionConfirmationMessage } from './SyncDeckManager.js'
+import { hasDownloadedSessionReportForSession } from './SyncDeckManager.js'
+import { resolveDownloadedSessionReportId } from './SyncDeckManager.js'
 import { getReportPreviewFocusableElements } from './SyncDeckManager.js'
 import { resolveReportPreviewDialogTabTarget } from './SyncDeckManager.js'
 
@@ -360,6 +362,21 @@ void test('end-session confirmation warns until the session report has been down
   )
   assert.doesNotMatch(
     buildEndSessionConfirmationMessage(true),
+    /will not be able to download a report once the session is ended/i,
+  )
+})
+
+void test('end-session confirmation reflects successful and failed session report downloads', () => {
+  const sessionId = 'session-123'
+  const successfulDownloadId = resolveDownloadedSessionReportId(null, sessionId, true)
+  assert.doesNotMatch(
+    buildEndSessionConfirmationMessage(hasDownloadedSessionReportForSession(successfulDownloadId, sessionId)),
+    /will not be able to download a report once the session is ended/i,
+  )
+
+  const failedDownloadId = resolveDownloadedSessionReportId(null, sessionId, false)
+  assert.match(
+    buildEndSessionConfirmationMessage(hasDownloadedSessionReportForSession(failedDownloadId, sessionId)),
     /will not be able to download a report once the session is ended/i,
   )
 })

--- a/activities/syncdeck/client/manager/SyncDeckManager.test.tsx
+++ b/activities/syncdeck/client/manager/SyncDeckManager.test.tsx
@@ -71,6 +71,7 @@ import { resolveDeckActivityRequestsFromDeckDocument } from './SyncDeckManager.j
 import { buildReportContributionMap } from './SyncDeckManager.js'
 import { resolveReportContributionLabel } from './SyncDeckManager.js'
 import { buildReportPreviewSummary } from './SyncDeckManager.js'
+import { buildEndSessionConfirmationMessage } from './SyncDeckManager.js'
 import { getReportPreviewFocusableElements } from './SyncDeckManager.js'
 import { resolveReportPreviewDialogTabTarget } from './SyncDeckManager.js'
 
@@ -350,6 +351,17 @@ void test('buildReportPreviewSummary counts report availability states', () => {
     unsupportedCount: 1,
     unavailableCount: 1,
   })
+})
+
+void test('end-session confirmation warns until the session report has been downloaded', () => {
+  assert.match(
+    buildEndSessionConfirmationMessage(false),
+    /will not be able to download a report once the session is ended/i,
+  )
+  assert.doesNotMatch(
+    buildEndSessionConfirmationMessage(true),
+    /will not be able to download a report once the session is ended/i,
+  )
 })
 
 void test('validatePresentationUrl rejects empty and whitespace-only values', () => {

--- a/activities/syncdeck/client/manager/SyncDeckManager.tsx
+++ b/activities/syncdeck/client/manager/SyncDeckManager.tsx
@@ -1342,6 +1342,21 @@ export function buildEndSessionConfirmationMessage(hasDownloadedSessionReport: b
   return `${disconnectionWarning} You will not be able to download a report once the session is ended.`
 }
 
+export function resolveDownloadedSessionReportId(
+  currentDownloadedSessionReportId: string | null,
+  sessionId: string,
+  didDownloadSessionReport: boolean,
+): string | null {
+  return didDownloadSessionReport ? sessionId : currentDownloadedSessionReportId
+}
+
+export function hasDownloadedSessionReportForSession(
+  downloadedSessionReportId: string | null,
+  sessionId: string,
+): boolean {
+  return downloadedSessionReportId === sessionId
+}
+
 function resolveReportContributionClassName(
   contribution: ReportContributionState | undefined,
   isLoading: boolean,
@@ -3228,7 +3243,9 @@ const SyncDeckManager: FC = () => {
     if (!sessionId) return
 
     if (typeof window !== 'undefined') {
-      const confirmed = window.confirm(buildEndSessionConfirmationMessage(downloadedSessionReportId === sessionId))
+      const confirmed = window.confirm(buildEndSessionConfirmationMessage(
+        hasDownloadedSessionReportForSession(downloadedSessionReportId, sessionId),
+      ))
       if (!confirmed) return
     }
 
@@ -4566,6 +4583,7 @@ const SyncDeckManager: FC = () => {
 
     setIsDownloadingSessionReport(true)
     setSessionReportError(null)
+    let didDownloadSessionReport = false
     try {
       const response = await fetch(
         `/api/syncdeck/${encodeURIComponent(sessionId)}/report`,
@@ -4590,11 +4608,16 @@ const SyncDeckManager: FC = () => {
       downloadLink.click()
       document.body.removeChild(downloadLink)
       URL.revokeObjectURL(objectUrl)
-      setDownloadedSessionReportId(sessionId)
+      didDownloadSessionReport = true
       void refreshReportContributionStatus()
     } catch {
       setSessionReportError('Session report download failed. Check your connection and try again.')
     } finally {
+      setDownloadedSessionReportId((current) => resolveDownloadedSessionReportId(
+        current,
+        sessionId,
+        didDownloadSessionReport,
+      ))
       setIsDownloadingSessionReport(false)
     }
   }

--- a/activities/syncdeck/client/manager/SyncDeckManager.tsx
+++ b/activities/syncdeck/client/manager/SyncDeckManager.tsx
@@ -2232,7 +2232,7 @@ const SyncDeckManager: FC = () => {
   const [endingEmbeddedInstanceKey, setEndingEmbeddedInstanceKey] = useState<string | null>(null)
   const [pendingEmbeddedEndConfirmInstanceKey, setPendingEmbeddedEndConfirmInstanceKey] = useState<string | null>(null)
   const [isDownloadingSessionReport, setIsDownloadingSessionReport] = useState(false)
-  const [hasDownloadedSessionReport, setHasDownloadedSessionReport] = useState(false)
+  const [downloadedSessionReportId, setDownloadedSessionReportId] = useState<string | null>(null)
   const [sessionReportError, setSessionReportError] = useState<string | null>(null)
   const [reportContributionByInstanceKey, setReportContributionByInstanceKey] =
     useState<Record<string, ReportContributionState>>({})
@@ -3228,7 +3228,7 @@ const SyncDeckManager: FC = () => {
     if (!sessionId) return
 
     if (typeof window !== 'undefined') {
-      const confirmed = window.confirm(buildEndSessionConfirmationMessage(hasDownloadedSessionReport))
+      const confirmed = window.confirm(buildEndSessionConfirmationMessage(downloadedSessionReportId === sessionId))
       if (!confirmed) return
     }
 
@@ -4590,7 +4590,7 @@ const SyncDeckManager: FC = () => {
       downloadLink.click()
       document.body.removeChild(downloadLink)
       URL.revokeObjectURL(objectUrl)
-      setHasDownloadedSessionReport(true)
+      setDownloadedSessionReportId(sessionId)
       void refreshReportContributionStatus()
     } catch {
       setSessionReportError('Session report download failed. Check your connection and try again.')

--- a/activities/syncdeck/client/manager/SyncDeckManager.tsx
+++ b/activities/syncdeck/client/manager/SyncDeckManager.tsx
@@ -1333,6 +1333,15 @@ export function buildReportPreviewSummary(
   })
 }
 
+export function buildEndSessionConfirmationMessage(hasDownloadedSessionReport: boolean): string {
+  const disconnectionWarning = 'End this session? All students will be disconnected.'
+  if (hasDownloadedSessionReport) {
+    return disconnectionWarning
+  }
+
+  return `${disconnectionWarning} You will not be able to download a report once the session is ended.`
+}
+
 function resolveReportContributionClassName(
   contribution: ReportContributionState | undefined,
   isLoading: boolean,
@@ -2223,6 +2232,7 @@ const SyncDeckManager: FC = () => {
   const [endingEmbeddedInstanceKey, setEndingEmbeddedInstanceKey] = useState<string | null>(null)
   const [pendingEmbeddedEndConfirmInstanceKey, setPendingEmbeddedEndConfirmInstanceKey] = useState<string | null>(null)
   const [isDownloadingSessionReport, setIsDownloadingSessionReport] = useState(false)
+  const [hasDownloadedSessionReport, setHasDownloadedSessionReport] = useState(false)
   const [sessionReportError, setSessionReportError] = useState<string | null>(null)
   const [reportContributionByInstanceKey, setReportContributionByInstanceKey] =
     useState<Record<string, ReportContributionState>>({})
@@ -3218,7 +3228,7 @@ const SyncDeckManager: FC = () => {
     if (!sessionId) return
 
     if (typeof window !== 'undefined') {
-      const confirmed = window.confirm('End this session? All students will be disconnected.')
+      const confirmed = window.confirm(buildEndSessionConfirmationMessage(hasDownloadedSessionReport))
       if (!confirmed) return
     }
 
@@ -4580,6 +4590,7 @@ const SyncDeckManager: FC = () => {
       downloadLink.click()
       document.body.removeChild(downloadLink)
       URL.revokeObjectURL(objectUrl)
+      setHasDownloadedSessionReport(true)
       void refreshReportContributionStatus()
     } catch {
       setSessionReportError('Session report download failed. Check your connection and try again.')

--- a/scripts/typecheck-activities.mjs
+++ b/scripts/typecheck-activities.mjs
@@ -17,10 +17,15 @@ export function getActivityTargets(directoryEntries) {
     .sort((left, right) => left.localeCompare(right))
 }
 
-export function buildActivityTypecheckConfig(activityName) {
-  const config = ts.getParsedCommandLineOfConfigFile(activitiesTsconfigPath, {}, ts.sys)
+export function buildActivityTypecheckConfig(
+  activityName,
+  parseConfig = ts.getParsedCommandLineOfConfigFile,
+) {
+  const config = parseConfig(activitiesTsconfigPath, {}, ts.sys)
   if (!config) {
-    return { errors: [] }
+    return {
+      errors: [ts.createCompilerDiagnostic(ts.Diagnostics.Cannot_read_file_0, activitiesTsconfigPath)],
+    }
   }
 
   const includedDirectoryPrefixes = [

--- a/scripts/typecheck-activities.mjs
+++ b/scripts/typecheck-activities.mjs
@@ -67,6 +67,23 @@ export function typecheckActivity(activityName) {
   return false
 }
 
+export function runActivityTypecheckProcess(activityName, spawn = spawnSync) {
+  const result = spawn(process.execPath, [process.argv[1], activityName], { stdio: 'inherit' })
+  if (result.error) {
+    console.error(`Unable to typecheck activities/${activityName}: ${result.error.message}`)
+    return false
+  }
+
+  if (result.status === 0) {
+    return true
+  }
+
+  if (result.signal) {
+    console.error(`Typechecking activities/${activityName} ended with signal ${result.signal}.`)
+  }
+  return false
+}
+
 export function runActivityTypechecks({
   directoryEntries = readdirSync(activitiesDir, { withFileTypes: true }),
   runTarget = (target) => typecheckActivity(target),
@@ -89,7 +106,7 @@ if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
     process.exitCode = typecheckActivity(activityName) ? 0 : 1
   } else {
     process.exitCode = runActivityTypechecks({
-      runTarget: (target) => spawnSync(process.execPath, [process.argv[1], target], { stdio: 'inherit' }).status === 0,
+      runTarget: runActivityTypecheckProcess,
     }) ? 0 : 1
   }
 }

--- a/scripts/typecheck-activities.mjs
+++ b/scripts/typecheck-activities.mjs
@@ -12,7 +12,12 @@ const activitiesTsconfigPath = join(activitiesDir, 'tsconfig.json')
 
 export function getActivityTargets(directoryEntries) {
   return directoryEntries
-    .filter((entry) => entry.isDirectory() && !entry.name.startsWith('.') && entry.name !== 'node_modules')
+    .filter((entry) => (
+      entry.isDirectory()
+      && !entry.name.startsWith('.')
+      && entry.name !== 'node_modules'
+      && entry.name !== 'shared'
+    ))
     .map((entry) => entry.name)
     .sort((left, right) => left.localeCompare(right))
 }
@@ -100,10 +105,12 @@ export function runActivityTypechecks({
     return true
   }
 
-  return targets.every((target) => {
+  let succeeded = true
+  for (const target of targets) {
     console.log(`Typechecking activities/${target}`)
-    return runTarget(target)
-  })
+    succeeded = runTarget(target) && succeeded
+  }
+  return succeeded
 }
 
 if (process.argv[1] && typecheckActivitiesRunnerPath === process.argv[1]) {

--- a/scripts/typecheck-activities.mjs
+++ b/scripts/typecheck-activities.mjs
@@ -71,10 +71,10 @@ export function typecheckActivity(activityName) {
   return false
 }
 
-export function runActivityTypecheckProcess(activityName, spawn = spawnSync) {
+export function runActivityTypecheckProcess(activityName, spawn = spawnSync, reportError = console.error) {
   const result = spawn(process.execPath, [typecheckActivitiesRunnerPath, activityName], { stdio: 'inherit' })
   if (result.error) {
-    console.error(`Unable to typecheck activities/${activityName}: ${result.error.message}`)
+    reportError(`Unable to typecheck activities/${activityName}: ${result.error.message}`)
     return false
   }
 
@@ -83,7 +83,9 @@ export function runActivityTypecheckProcess(activityName, spawn = spawnSync) {
   }
 
   if (result.signal) {
-    console.error(`Typechecking activities/${activityName} ended with signal ${result.signal}.`)
+    reportError(`Typechecking activities/${activityName} ended with signal ${result.signal}.`)
+  } else {
+    reportError(`Typechecking activities/${activityName} exited with status ${result.status ?? 'unknown'}.`)
   }
   return false
 }

--- a/scripts/typecheck-activities.mjs
+++ b/scripts/typecheck-activities.mjs
@@ -1,10 +1,11 @@
 import { spawnSync } from 'node:child_process'
 import { readdirSync } from 'node:fs'
-import { dirname, join } from 'node:path'
+import { dirname, join, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import ts from 'typescript'
 
-const scriptsDir = dirname(fileURLToPath(import.meta.url))
+const typecheckActivitiesRunnerPath = fileURLToPath(import.meta.url)
+const scriptsDir = dirname(typecheckActivitiesRunnerPath)
 const repositoryRoot = dirname(scriptsDir)
 const activitiesDir = join(repositoryRoot, 'activities')
 const activitiesTsconfigPath = join(activitiesDir, 'tsconfig.json')
@@ -17,25 +18,23 @@ export function getActivityTargets(directoryEntries) {
 }
 
 export function buildActivityTypecheckConfig(activityName) {
-  const readResult = ts.readConfigFile(activitiesTsconfigPath, ts.sys.readFile)
-  if (readResult.error) {
-    return { errors: [readResult.error] }
+  const config = ts.getParsedCommandLineOfConfigFile(activitiesTsconfigPath, {}, ts.sys)
+  if (!config) {
+    return { errors: [] }
   }
 
-  const config = {
-    ...readResult.config,
-    include: [
-      `${activityName}/client/**/*`,
-      `${activityName}/server/**/*`,
-      `${activityName}/shared/**/*`,
-      `${activityName}/playwright/**/*`,
-      `${activityName}/activity.config.*`,
-      'shared/**/*',
-      '../types/**/*.d.ts',
-    ],
-  }
+  const includedDirectoryPrefixes = [
+    join(activitiesDir, activityName),
+    join(activitiesDir, 'shared'),
+    join(repositoryRoot, 'types'),
+  ].map((directory) => `${directory}${sep}`)
 
-  return ts.parseJsonConfigFileContent(config, ts.sys, activitiesDir, undefined, activitiesTsconfigPath)
+  return {
+    ...config,
+    fileNames: config.fileNames.filter((fileName) => (
+      includedDirectoryPrefixes.some((directoryPrefix) => fileName.startsWith(directoryPrefix))
+    )),
+  }
 }
 
 function formatDiagnostics(diagnostics) {
@@ -68,7 +67,7 @@ export function typecheckActivity(activityName) {
 }
 
 export function runActivityTypecheckProcess(activityName, spawn = spawnSync) {
-  const result = spawn(process.execPath, [process.argv[1], activityName], { stdio: 'inherit' })
+  const result = spawn(process.execPath, [typecheckActivitiesRunnerPath, activityName], { stdio: 'inherit' })
   if (result.error) {
     console.error(`Unable to typecheck activities/${activityName}: ${result.error.message}`)
     return false
@@ -100,7 +99,7 @@ export function runActivityTypechecks({
   })
 }
 
-if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+if (process.argv[1] && typecheckActivitiesRunnerPath === process.argv[1]) {
   const activityName = process.argv[2]
   if (activityName) {
     process.exitCode = typecheckActivity(activityName) ? 0 : 1

--- a/scripts/typecheck-activities.mjs
+++ b/scripts/typecheck-activities.mjs
@@ -1,0 +1,95 @@
+import { spawnSync } from 'node:child_process'
+import { readdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import ts from 'typescript'
+
+const scriptsDir = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = dirname(scriptsDir)
+const activitiesDir = join(repositoryRoot, 'activities')
+const activitiesTsconfigPath = join(activitiesDir, 'tsconfig.json')
+
+export function getActivityTargets(directoryEntries) {
+  return directoryEntries
+    .filter((entry) => entry.isDirectory() && !entry.name.startsWith('.') && entry.name !== 'node_modules')
+    .map((entry) => entry.name)
+    .sort((left, right) => left.localeCompare(right))
+}
+
+export function buildActivityTypecheckConfig(activityName) {
+  const readResult = ts.readConfigFile(activitiesTsconfigPath, ts.sys.readFile)
+  if (readResult.error) {
+    return { errors: [readResult.error] }
+  }
+
+  const config = {
+    ...readResult.config,
+    include: [
+      `${activityName}/client/**/*`,
+      `${activityName}/server/**/*`,
+      `${activityName}/shared/**/*`,
+      `${activityName}/playwright/**/*`,
+      `${activityName}/activity.config.*`,
+      'shared/**/*',
+      '../types/**/*.d.ts',
+    ],
+  }
+
+  return ts.parseJsonConfigFileContent(config, ts.sys, activitiesDir, undefined, activitiesTsconfigPath)
+}
+
+function formatDiagnostics(diagnostics) {
+  return ts.formatDiagnosticsWithColorAndContext(diagnostics, {
+    getCanonicalFileName: (fileName) => fileName,
+    getCurrentDirectory: () => repositoryRoot,
+    getNewLine: () => '\n',
+  })
+}
+
+export function typecheckActivity(activityName) {
+  const parsedConfig = buildActivityTypecheckConfig(activityName)
+  if (parsedConfig.errors?.length) {
+    console.error(formatDiagnostics(parsedConfig.errors))
+    return false
+  }
+
+  const program = ts.createProgram({
+    rootNames: parsedConfig.fileNames,
+    options: parsedConfig.options,
+    projectReferences: parsedConfig.projectReferences,
+  })
+  const diagnostics = ts.getPreEmitDiagnostics(program)
+  if (diagnostics.length === 0) {
+    return true
+  }
+
+  console.error(formatDiagnostics(diagnostics))
+  return false
+}
+
+export function runActivityTypechecks({
+  directoryEntries = readdirSync(activitiesDir, { withFileTypes: true }),
+  runTarget = (target) => typecheckActivity(target),
+} = {}) {
+  const targets = getActivityTargets(directoryEntries)
+  if (targets.length === 0) {
+    console.log('No activity directories found to typecheck.')
+    return true
+  }
+
+  return targets.every((target) => {
+    console.log(`Typechecking activities/${target}`)
+    return runTarget(target)
+  })
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  const activityName = process.argv[2]
+  if (activityName) {
+    process.exitCode = typecheckActivity(activityName) ? 0 : 1
+  } else {
+    process.exitCode = runActivityTypechecks({
+      runTarget: (target) => spawnSync(process.execPath, [process.argv[1], target], { stdio: 'inherit' }).status === 0,
+    }) ? 0 : 1
+  }
+}

--- a/scripts/typecheck-activities.test.mjs
+++ b/scripts/typecheck-activities.test.mjs
@@ -20,9 +20,9 @@ void test('activity typecheck runner uses sorted activity directories', () => {
 void test('activity typecheck config scopes sources to one activity while retaining shared contracts', () => {
   const config = buildActivityTypecheckConfig('syncdeck')
   assert.deepEqual(config.errors, [])
-  assert.ok(config.fileNames.some((fileName) => fileName.includes('/activities/syncdeck/')))
-  assert.ok(config.fileNames.some((fileName) => fileName.includes('/activities/shared/')))
-  assert.equal(config.fileNames.some((fileName) => fileName.includes('/activities/resonance/')), false)
+  assert.ok(config.fileNames.some((fileName) => /[\\/]activities[\\/]syncdeck[\\/]/.test(fileName)))
+  assert.ok(config.fileNames.some((fileName) => /[\\/]activities[\\/]shared[\\/]/.test(fileName)))
+  assert.equal(config.fileNames.some((fileName) => /[\\/]activities[\\/]resonance[\\/]/.test(fileName)), false)
   assert.equal(config.options.strict, true)
   assert.equal(config.options.noUnusedLocals, true)
 })
@@ -57,6 +57,16 @@ void test('activity typecheck runner reports a subprocess spawn failure', () => 
   )
 })
 
+void test('activity typecheck runner reports a non-zero subprocess exit status', () => {
+  const errors = []
+  console.info('[TEST] Expected activity typecheck subprocess non-zero exit status.')
+  assert.equal(
+    runActivityTypecheckProcess('syncdeck', () => ({ status: 1 }), (message) => errors.push(message)),
+    false,
+  )
+  assert.match(errors[0], /exited with status 1/i)
+})
+
 void test('activity typecheck runner spawns this runner module for each activity', () => {
   let spawnedArguments
   assert.equal(
@@ -67,6 +77,6 @@ void test('activity typecheck runner spawns this runner module for each activity
     true,
   )
   assert.equal(spawnedArguments[0], process.execPath)
-  assert.match(spawnedArguments[1][0], /scripts\/typecheck-activities\.mjs$/)
+  assert.match(spawnedArguments[1][0], /scripts[\\/]typecheck-activities\.mjs$/)
   assert.equal(spawnedArguments[1][1], 'syncdeck')
 })

--- a/scripts/typecheck-activities.test.mjs
+++ b/scripts/typecheck-activities.test.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { buildActivityTypecheckConfig, getActivityTargets, runActivityTypechecks } from './typecheck-activities.mjs'
+
+void test('activity typecheck runner uses sorted activity directories', () => {
+  assert.deepEqual(getActivityTargets([
+    { name: 'syncdeck', isDirectory: () => true },
+    { name: '.cache', isDirectory: () => true },
+    { name: 'node_modules', isDirectory: () => true },
+    { name: 'resonance', isDirectory: () => true },
+    { name: 'README.md', isDirectory: () => false },
+  ]), ['resonance', 'syncdeck'])
+})
+
+void test('activity typecheck config scopes sources to one activity while retaining shared contracts', () => {
+  const config = buildActivityTypecheckConfig('syncdeck')
+  assert.deepEqual(config.errors, [])
+  assert.ok(config.fileNames.some((fileName) => fileName.includes('/activities/syncdeck/')))
+  assert.ok(config.fileNames.some((fileName) => fileName.includes('/activities/shared/')))
+  assert.equal(config.fileNames.some((fileName) => fileName.includes('/activities/resonance/')), false)
+})
+
+void test('activity typecheck runner invokes each activity independently', () => {
+  const checkedTargets = []
+  const success = runActivityTypechecks({
+    directoryEntries: [
+      { name: 'syncdeck', isDirectory: () => true },
+      { name: 'resonance', isDirectory: () => true },
+    ],
+    runTarget: (target) => {
+      checkedTargets.push(target)
+      return true
+    },
+  })
+
+  assert.equal(success, true)
+  assert.deepEqual(checkedTargets, ['resonance', 'syncdeck'])
+})

--- a/scripts/typecheck-activities.test.mjs
+++ b/scripts/typecheck-activities.test.mjs
@@ -23,6 +23,8 @@ void test('activity typecheck config scopes sources to one activity while retain
   assert.ok(config.fileNames.some((fileName) => fileName.includes('/activities/syncdeck/')))
   assert.ok(config.fileNames.some((fileName) => fileName.includes('/activities/shared/')))
   assert.equal(config.fileNames.some((fileName) => fileName.includes('/activities/resonance/')), false)
+  assert.equal(config.options.strict, true)
+  assert.equal(config.options.noUnusedLocals, true)
 })
 
 void test('activity typecheck runner invokes each activity independently', () => {
@@ -48,4 +50,18 @@ void test('activity typecheck runner reports a subprocess spawn failure', () => 
     runActivityTypecheckProcess('syncdeck', () => ({ error: new Error('permission denied') })),
     false,
   )
+})
+
+void test('activity typecheck runner spawns this runner module for each activity', () => {
+  let spawnedArguments
+  assert.equal(
+    runActivityTypecheckProcess('syncdeck', (...arguments_) => {
+      spawnedArguments = arguments_
+      return { status: 0 }
+    }),
+    true,
+  )
+  assert.equal(spawnedArguments[0], process.execPath)
+  assert.match(spawnedArguments[1][0], /scripts\/typecheck-activities\.mjs$/)
+  assert.equal(spawnedArguments[1][1], 'syncdeck')
 })

--- a/scripts/typecheck-activities.test.mjs
+++ b/scripts/typecheck-activities.test.mjs
@@ -1,6 +1,11 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { buildActivityTypecheckConfig, getActivityTargets, runActivityTypechecks } from './typecheck-activities.mjs'
+import {
+  buildActivityTypecheckConfig,
+  getActivityTargets,
+  runActivityTypecheckProcess,
+  runActivityTypechecks,
+} from './typecheck-activities.mjs'
 
 void test('activity typecheck runner uses sorted activity directories', () => {
   assert.deepEqual(getActivityTargets([
@@ -35,4 +40,12 @@ void test('activity typecheck runner invokes each activity independently', () =>
 
   assert.equal(success, true)
   assert.deepEqual(checkedTargets, ['resonance', 'syncdeck'])
+})
+
+void test('activity typecheck runner reports a subprocess spawn failure', () => {
+  console.info('[TEST] Expected activity typecheck subprocess spawn failure.')
+  assert.equal(
+    runActivityTypecheckProcess('syncdeck', () => ({ error: new Error('permission denied') })),
+    false,
+  )
 })

--- a/scripts/typecheck-activities.test.mjs
+++ b/scripts/typecheck-activities.test.mjs
@@ -12,6 +12,7 @@ void test('activity typecheck runner uses sorted activity directories', () => {
     { name: 'syncdeck', isDirectory: () => true },
     { name: '.cache', isDirectory: () => true },
     { name: 'node_modules', isDirectory: () => true },
+    { name: 'shared', isDirectory: () => true },
     { name: 'resonance', isDirectory: () => true },
     { name: 'README.md', isDirectory: () => false },
   ]), ['resonance', 'syncdeck'])
@@ -46,6 +47,24 @@ void test('activity typecheck runner invokes each activity independently', () =>
   })
 
   assert.equal(success, true)
+  assert.deepEqual(checkedTargets, ['resonance', 'syncdeck'])
+})
+
+void test('activity typecheck runner continues after an activity failure', () => {
+  const checkedTargets = []
+  console.info('[TEST] Expected one activity typecheck failure while later targets still run.')
+  const success = runActivityTypechecks({
+    directoryEntries: [
+      { name: 'syncdeck', isDirectory: () => true },
+      { name: 'resonance', isDirectory: () => true },
+    ],
+    runTarget: (target) => {
+      checkedTargets.push(target)
+      return target !== 'resonance'
+    },
+  })
+
+  assert.equal(success, false)
   assert.deepEqual(checkedTargets, ['resonance', 'syncdeck'])
 })
 

--- a/scripts/typecheck-activities.test.mjs
+++ b/scripts/typecheck-activities.test.mjs
@@ -27,6 +27,11 @@ void test('activity typecheck config scopes sources to one activity while retain
   assert.equal(config.options.noUnusedLocals, true)
 })
 
+void test('activity typecheck config reports an unreadable base configuration', () => {
+  const config = buildActivityTypecheckConfig('syncdeck', () => undefined)
+  assert.equal(config.errors.length, 1)
+})
+
 void test('activity typecheck runner invokes each activity independently', () => {
   const checkedTargets = []
   const success = runActivityTypechecks({


### PR DESCRIPTION
## Summary

- warn SyncDeck instructors before ending a session when they have not initiated a session-report download
- add a per-activity TypeScript runner that uses a fresh process for each activity, matching isolated activity linting

## Why

Ending a SyncDeck session deletes the report source data, so instructors need a clear warning before that irreversible action. The aggregate activities typecheck could also retain enough compiler memory to be killed before completing.

## Validation

- `npm run test:activities:file -- activities/syncdeck/client/manager/SyncDeckManager.test.tsx`
- `npm --workspace activities run typecheck`
- `node --test scripts/typecheck-activities.test.mjs`
- `npx eslint scripts/typecheck-activities.mjs scripts/typecheck-activities.test.mjs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - End-session confirmation now reflects whether the current session report has been downloaded.
  - Users are warned when ending a session would prevent access to an undownloaded report.

- **Bug Fixes**
  - Removed the unnecessary report-download warning when the report has already been downloaded.

- **Testing**
  - Added coverage for confirmation messaging and activity-specific type checking.

- **Documentation**
  - Updated guidance on session-report handling and activity type-checking practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->