### PR TITLE
fix(mobcode): handle triple-quoted Brython literals

### DIFF
--- a/.agent/knowledge/react-best-practices.md
+++ b/.agent/knowledge/react-best-practices.md
@@ -12,6 +12,16 @@ Capture reusable React patterns, performance guidance, and accessibility convent
 - Tradeoffs:
 - Owner:
 
+## MobCode Layout
+
+- Date: 2026-07-31
+- Area: activities | mobcode | layout
+- Pattern: Bound the flex shell, grid row, and direct CodeMirror wrapper with `minmax(0, 1fr)`/`min-height: 0` so only the editor scroller owns long-source overflow.
+- Why it helps: Without all three bounds, CodeMirror expands to source height, the document scrolls, and the activity header leaves the viewport.
+- Example (file/path): `activities/mobcode/client/styles.css`; `activities/mobcode/playwright/runner.spec.ts`.
+- Tradeoffs: The sidebar now scrolls internally when its file/student controls exceed the available workspace height.
+- Owner: Codex
+
 ## Performance Optimization
 
 ### Memoize Expensive Computations

--- a/.agent/knowledge/repo_discoveries.md
+++ b/.agent/knowledge/repo_discoveries.md
@@ -16,10 +16,10 @@ Use this log for durable findings that future contributors and agents should reu
 
 - Date: 2026-07-31
 - Area: activities | mobcode | Python runner
-- Discovery: MobCode's Brython async-entry source transform must classify every line of a triple-quoted literal as non-executable. Literal text can look like a function or `input()` call and can have less indentation than its surrounding function, so line-by-line transforms otherwise rewrite it or incorrectly close the function scope.
+- Discovery: MobCode's Brython async-entry source transform must distinguish literal-only lines from an opening triple-quote line. Literal-only text can look like a function or `input()` call and can have less indentation than its surrounding function, while the opening line may contain executable code that still needs analysis and rewriting.
 - Why it matters: The runner wraps user Python in an async function to support terminal input. Its opening line must be indented as executable code, but following literal-only lines must retain their original columns so their string value is unchanged.
 - Evidence: `activities/mobcode/client/runner/runnerUtils.ts`; `activities/mobcode/client/runner/runnerUtils.test.ts`; `activities/mobcode/playwright/runner.spec.ts`.
-- Follow-up action: Extend the literal-line classifier before adding any further line-oriented Python rewrites so multiline strings remain isolated from executable-source analysis.
+- Follow-up action: Extend the literal-line classifier before adding line-oriented Python rewrites so literal-only content remains isolated without skipping executable delimiter lines.
 - Owner: Codex
 
 - Date: 2026-07-27

--- a/.agent/knowledge/repo_discoveries.md
+++ b/.agent/knowledge/repo_discoveries.md
@@ -14,6 +14,14 @@ Use this log for durable findings that future contributors and agents should reu
 
 ## Discoveries
 
+- Date: 2026-07-31
+- Area: activities | mobcode | Python runner
+- Discovery: MobCode's Brython async-entry source transform must classify every line of a triple-quoted literal as non-executable. Literal text can look like a function or `input()` call and can have less indentation than its surrounding function, so line-by-line transforms otherwise rewrite it or incorrectly close the function scope.
+- Why it matters: The runner wraps user Python in an async function to support terminal input. Its opening line must be indented as executable code, but following literal-only lines must retain their original columns so their string value is unchanged.
+- Evidence: `activities/mobcode/client/runner/runnerUtils.ts`; `activities/mobcode/client/runner/runnerUtils.test.ts`; `activities/mobcode/playwright/runner.spec.ts`.
+- Follow-up action: Extend the literal-line classifier before adding any further line-oriented Python rewrites so multiline strings remain isolated from executable-source analysis.
+- Owner: Codex
+
 - Date: 2026-07-27
 - Area: client | activities | syncdeck | reporting
 - Discovery: SyncDeck's end-session confirmation can only know that the browser successfully initiated a report download in the active manager view; browsers do not expose a reliable signal that a user retained the downloaded file.

--- a/activities/mobcode/client/runner/runnerUtils.test.ts
+++ b/activities/mobcode/client/runner/runnerUtils.test.ts
@@ -353,6 +353,35 @@ void test('buildBrythonAsyncEntrySource gives blank and comment-only files a val
   }
 })
 
+void test('buildBrythonAsyncEntrySource safely indents triple-quoted literal content', () => {
+  const source = buildBrythonAsyncEntrySource([
+    'def show_example():',
+    '    example = """',
+    'def prompt():',
+    '    return input("This is literal text")',
+    '"""',
+    '    return example',
+    'print(show_example())',
+  ].join('\n'))
+
+  assert.match(source, /def show_example\(\):/)
+  assert.doesNotMatch(source, /async def show_example\(\):/)
+  assert.match(source, /def prompt\(\):\n {4}return input\("This is literal text"\)\n"""/)
+  assert.doesNotMatch(source, /await mobcode_input\("This is literal text"\)/)
+  assert.match(source, / {8}return example/)
+})
+
+void test('buildBrythonAsyncEntrySource preserves triple-quoted string values', () => {
+  const source = buildBrythonAsyncEntrySource([
+    "s = '''",
+    'hi',
+    "'''",
+    'print(len(s))',
+  ].join('\n'))
+
+  assert.match(source, / {4}s = '''\nhi\n'''\n {4}print\(len\(s\)\)/)
+})
+
 void test('buildBrythonAsyncEntrySource rewrites class method input', () => {
   const source = buildBrythonAsyncEntrySource([
     'class Prompter:',

--- a/activities/mobcode/client/runner/runnerUtils.test.ts
+++ b/activities/mobcode/client/runner/runnerUtils.test.ts
@@ -327,6 +327,17 @@ void test('buildBrythonModuleSource transforms functions without adding entry wr
   assert.doesNotMatch(source, /mobcode_run_async/)
 })
 
+void test('buildBrythonModuleSource preserves triple-quoted literal indentation', () => {
+  const source = buildBrythonModuleSource([
+    'def message():',
+    '    return """',
+    '    keep these spaces',
+    '    """',
+  ].join('\n'))
+
+  assert.match(source, /return """\n {4}keep these spaces\n {4}"""/)
+})
+
 void test('buildBrythonAsyncEntrySource rewrites top-level and function input', () => {
   const source = buildBrythonAsyncEntrySource([
     'name = input("Name?")',
@@ -380,6 +391,18 @@ void test('buildBrythonAsyncEntrySource preserves triple-quoted string values', 
   ].join('\n'))
 
   assert.match(source, / {4}s = '''\nhi\n'''\n {4}print\(len\(s\)\)/)
+})
+
+void test('buildBrythonAsyncEntrySource analyzes code on an opening triple-quote line', () => {
+  const source = buildBrythonAsyncEntrySource([
+    'from time import sleep; example = """',
+    'literal text',
+    '"""',
+    'sleep(0)',
+  ].join('\n'))
+
+  assert.match(source, /from time import sleep; example = """\nliteral text\n"""/)
+  assert.match(source, /await mobcode_sleep\(0\)/)
 })
 
 void test('buildBrythonAsyncEntrySource rewrites class method input', () => {

--- a/activities/mobcode/client/runner/runnerUtils.ts
+++ b/activities/mobcode/client/runner/runnerUtils.ts
@@ -180,6 +180,77 @@ function indentationWidth(value: string): number {
   return width
 }
 
+/**
+ * Identify lines that form part of a multiline string literal. The async-entry
+ * wrapper must indent the opening executable line, but adding that indentation
+ * to multiline literal content changes the value. Source transforms must also
+ * not mistake literal text for Python statements or use its indentation to end
+ * a surrounding function block.
+ */
+interface TripleQuotedStringLineInfo {
+  literalLines: ReadonlySet<number>
+  linesRequiringWrapperIndent: ReadonlySet<number>
+}
+
+function tripleQuotedStringLines(lines: readonly string[]): TripleQuotedStringLineInfo {
+  const literalLines = new Set<number>()
+  const linesRequiringWrapperIndent = new Set<number>()
+  let quote: '"' | "'" | null = null
+
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+    const line = lines[lineIndex] ?? ''
+    let index = 0
+    while (index < line.length) {
+      const character = line[index] ?? ''
+      const nextThree = line.slice(index, index + 3)
+
+      if (quote) {
+        literalLines.add(lineIndex)
+        if (character === '\\') {
+          index += 2
+          continue
+        }
+        if (nextThree === quote.repeat(3)) {
+          index += 3
+          quote = null
+          continue
+        }
+        index += 1
+        continue
+      }
+
+      if (character === '#') break
+      if ((character === '"' || character === "'") && nextThree === character.repeat(3)) {
+        literalLines.add(lineIndex)
+        // The opening line is still executable Python (or the function's
+        // docstring), so it needs the wrapper's block indentation. Subsequent
+        // physical string lines do not: adding spaces there changes the value.
+        linesRequiringWrapperIndent.add(lineIndex)
+        quote = character
+        index += 3
+        continue
+      }
+      if (character === '"' || character === "'") {
+        const stringQuote = character
+        index += 1
+        while (index < line.length) {
+          const stringCharacter = line[index] ?? ''
+          if (stringCharacter === '\\') {
+            index += 2
+            continue
+          }
+          index += 1
+          if (stringCharacter === stringQuote) break
+        }
+        continue
+      }
+      index += 1
+    }
+  }
+
+  return { literalLines, linesRequiringWrapperIndent }
+}
+
 function rewriteCallNamesForAwait(line: string, names: ReadonlySet<string>, replacementName?: string): string {
   let output = ''
   let index = 0
@@ -396,10 +467,16 @@ interface PythonBlock {
   callStyle: 'function' | 'method'
 }
 
-function isTopLevelClassMethod(lines: readonly string[], lineIndex: number, startIndent: number): boolean {
+function isTopLevelClassMethod(
+  lines: readonly string[],
+  lineIndex: number,
+  startIndent: number,
+  literalLines: ReadonlySet<number>,
+): boolean {
   if (startIndent === 0) return false
 
   for (let index = lineIndex - 1; index >= 0; index -= 1) {
+    if (literalLines.has(index)) continue
     const line = lines[index] ?? ''
     const trimmed = line.trim()
     if (!trimmed || trimmed.startsWith('#')) continue
@@ -412,10 +489,11 @@ function isTopLevelClassMethod(lines: readonly string[], lineIndex: number, star
   return false
 }
 
-function topLevelPythonBlocks(lines: readonly string[]): PythonBlock[] {
+function topLevelPythonBlocks(lines: readonly string[], literalLines: ReadonlySet<number>): PythonBlock[] {
   const blocks: PythonBlock[] = []
-  const rewriteBareSleep = importsTimeSleep(lines)
+  const rewriteBareSleep = importsTimeSleep(lines.filter((_, lineIndex) => !literalLines.has(lineIndex)))
   for (let index = 0; index < lines.length; index += 1) {
+    if (literalLines.has(index)) continue
     const line = lines[index] ?? ''
     const trimmed = line.trim()
     const match = trimmed.match(/^def\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/)
@@ -424,7 +502,7 @@ function topLevelPythonBlocks(lines: readonly string[]): PythonBlock[] {
     const startIndent = indentationWidth(line)
     const callStyle: PythonBlock['callStyle'] | null = startIndent === 0
       ? 'function'
-      : isTopLevelClassMethod(lines, index, startIndent) ? 'method' : null
+      : isTopLevelClassMethod(lines, index, startIndent, literalLines) ? 'method' : null
     if (callStyle === null) continue
 
     let bodyEndLine = index
@@ -432,6 +510,10 @@ function topLevelPythonBlocks(lines: readonly string[]): PythonBlock[] {
     let nestedBlockIndent: number | null = null
     for (let bodyIndex = index + 1; bodyIndex < lines.length; bodyIndex += 1) {
       const bodyLine = lines[bodyIndex] ?? ''
+      if (literalLines.has(bodyIndex)) {
+        bodyEndLine = bodyIndex
+        continue
+      }
       const bodyTrimmed = bodyLine.trim()
       if (!bodyTrimmed || bodyTrimmed.startsWith('#')) {
         bodyEndLine = bodyIndex
@@ -490,8 +572,10 @@ function buildBrythonTransformedSource(
   options: { rewriteTopLevelInput: boolean },
 ): string {
   const lines = source.split(/\r?\n/)
-  const rewriteBareSleep = importsTimeSleep(lines)
-  const inputBlocks = topLevelPythonBlocks(lines)
+  const { literalLines, linesRequiringWrapperIndent } = tripleQuotedStringLines(lines)
+  const executableLines = lines.filter((_, lineIndex) => !literalLines.has(lineIndex))
+  const rewriteBareSleep = importsTimeSleep(executableLines)
+  const inputBlocks = topLevelPythonBlocks(lines, literalLines)
     .filter((block) => block.name !== '' && block.containsInput)
   const asyncInputFunctionNames = new Set(inputBlocks
     .filter((block) => block.callStyle === 'function')
@@ -502,6 +586,7 @@ function buildBrythonTransformedSource(
   const inputBlockByStartLine = new Map(inputBlocks.map((block) => [block.startLine, block]))
   const functionScopes: number[] = []
   const transformedLines = lines.map((line, lineIndex) => {
+    if (literalLines.has(lineIndex)) return line
     const trimmed = line.trim()
     if (!trimmed || trimmed.startsWith('#')) return line
 
@@ -537,7 +622,11 @@ function buildBrythonTransformedSource(
     return trimmed !== '' && !trimmed.startsWith('#')
   })
   const userBody = hasExecutableLine
-    ? transformedLines.map((line) => `    ${line}`).join('\n')
+    ? transformedLines.map((line, lineIndex) => (
+      literalLines.has(lineIndex) && !linesRequiringWrapperIndent.has(lineIndex)
+        ? line
+        : `    ${line}`
+    )).join('\n')
     : '    pass'
 
   return userBody

--- a/activities/mobcode/client/runner/runnerUtils.ts
+++ b/activities/mobcode/client/runner/runnerUtils.ts
@@ -489,9 +489,12 @@ function isTopLevelClassMethod(
   return false
 }
 
-function topLevelPythonBlocks(lines: readonly string[], literalLines: ReadonlySet<number>): PythonBlock[] {
+function topLevelPythonBlocks(
+  lines: readonly string[],
+  literalLines: ReadonlySet<number>,
+  rewriteBareSleep: boolean,
+): PythonBlock[] {
   const blocks: PythonBlock[] = []
-  const rewriteBareSleep = importsTimeSleep(lines.filter((_, lineIndex) => !literalLines.has(lineIndex)))
   for (let index = 0; index < lines.length; index += 1) {
     if (literalLines.has(index)) continue
     const line = lines[index] ?? ''
@@ -575,7 +578,7 @@ function buildBrythonTransformedSource(
   const { literalLines, linesRequiringWrapperIndent } = tripleQuotedStringLines(lines)
   const executableLines = lines.filter((_, lineIndex) => !literalLines.has(lineIndex))
   const rewriteBareSleep = importsTimeSleep(executableLines)
-  const inputBlocks = topLevelPythonBlocks(lines, literalLines)
+  const inputBlocks = topLevelPythonBlocks(lines, literalLines, rewriteBareSleep)
     .filter((block) => block.name !== '' && block.containsInput)
   const asyncInputFunctionNames = new Set(inputBlocks
     .filter((block) => block.callStyle === 'function')

--- a/activities/mobcode/client/runner/runnerUtils.ts
+++ b/activities/mobcode/client/runner/runnerUtils.ts
@@ -184,8 +184,9 @@ function indentationWidth(value: string): number {
  * Identify lines that form part of a multiline string literal. The async-entry
  * wrapper must indent the opening executable line, but adding that indentation
  * to multiline literal content changes the value. Source transforms must also
- * not mistake literal text for Python statements or use its indentation to end
- * a surrounding function block.
+ * not mistake literal-only text for Python statements or use its indentation to
+ * end a surrounding function block. The opening delimiter line remains
+ * executable so any code on it is still analyzed and rewritten.
  */
 interface TripleQuotedStringLineInfo {
   literalLines: ReadonlySet<number>
@@ -548,7 +549,7 @@ function topLevelPythonBlocks(
 }
 
 export function buildBrythonAsyncEntrySource(source: string): string {
-  const userBody = buildBrythonTransformedSource(source, { rewriteTopLevelInput: true })
+  const userBody = buildBrythonTransformedSource(source, { rewriteTopLevelInput: true, indentForAsyncEntry: true })
 
   return `async def __mobcode_user_main__():
 ${userBody || '    pass'}
@@ -567,18 +568,21 @@ mobcode_run_async(__mobcode_run__())
 }
 
 export function buildBrythonModuleSource(source: string): string {
-  return buildBrythonTransformedSource(source, { rewriteTopLevelInput: false }).replace(/^ {4}/gm, '')
+  return buildBrythonTransformedSource(source, { rewriteTopLevelInput: false, indentForAsyncEntry: false })
 }
 
 function buildBrythonTransformedSource(
   source: string,
-  options: { rewriteTopLevelInput: boolean },
+  options: { rewriteTopLevelInput: boolean; indentForAsyncEntry: boolean },
 ): string {
   const lines = source.split(/\r?\n/)
   const { literalLines, linesRequiringWrapperIndent } = tripleQuotedStringLines(lines)
-  const executableLines = lines.filter((_, lineIndex) => !literalLines.has(lineIndex))
+  const literalOnlyLines = new Set(
+    Array.from(literalLines).filter((lineIndex) => !linesRequiringWrapperIndent.has(lineIndex)),
+  )
+  const executableLines = lines.filter((_, lineIndex) => !literalOnlyLines.has(lineIndex))
   const rewriteBareSleep = importsTimeSleep(executableLines)
-  const inputBlocks = topLevelPythonBlocks(lines, literalLines, rewriteBareSleep)
+  const inputBlocks = topLevelPythonBlocks(lines, literalOnlyLines, rewriteBareSleep)
     .filter((block) => block.name !== '' && block.containsInput)
   const asyncInputFunctionNames = new Set(inputBlocks
     .filter((block) => block.callStyle === 'function')
@@ -589,7 +593,7 @@ function buildBrythonTransformedSource(
   const inputBlockByStartLine = new Map(inputBlocks.map((block) => [block.startLine, block]))
   const functionScopes: number[] = []
   const transformedLines = lines.map((line, lineIndex) => {
-    if (literalLines.has(lineIndex)) return line
+    if (literalOnlyLines.has(lineIndex)) return line
     const trimmed = line.trim()
     if (!trimmed || trimmed.startsWith('#')) return line
 
@@ -624,15 +628,13 @@ function buildBrythonTransformedSource(
     const trimmed = line.trim()
     return trimmed !== '' && !trimmed.startsWith('#')
   })
-  const userBody = hasExecutableLine
-    ? transformedLines.map((line, lineIndex) => (
-      literalLines.has(lineIndex) && !linesRequiringWrapperIndent.has(lineIndex)
-        ? line
-        : `    ${line}`
-    )).join('\n')
-    : '    pass'
+  if (!hasExecutableLine) return options.indentForAsyncEntry ? '    pass' : 'pass'
 
-  return userBody
+  return options.indentForAsyncEntry
+    ? transformedLines.map((line, lineIndex) => (
+      literalOnlyLines.has(lineIndex) ? line : `    ${line}`
+    )).join('\n')
+    : transformedLines.join('\n')
 }
 
 export function buildBrythonRunnerHtml(payload: BrythonRunnerPayload): string {

--- a/activities/mobcode/client/styles.css
+++ b/activities/mobcode/client/styles.css
@@ -1,7 +1,10 @@
 .mobcode-shell {
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
+  height: 100vh;
+  height: 100dvh;
+  min-height: 0;
+  overflow: hidden;
   background: #f8fafc;
 }
 
@@ -9,19 +12,30 @@
   display: grid;
   flex: 1;
   grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
+  grid-template-rows: minmax(0, 1fr);
   min-height: 0;
+  overflow: hidden;
 }
 
 .mobcode-sidebar {
   display: flex;
   flex-direction: column;
   min-height: 0;
+  overflow: auto;
 }
 
 .mobcode-editor-pane {
+  display: flex;
   min-width: 0;
   min-height: 0;
+  overflow: hidden;
   background: #ffffff;
+}
+
+.mobcode-editor-pane > div {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
 }
 
 .mobcode-header-actions {

--- a/activities/mobcode/playwright/runner.spec.ts
+++ b/activities/mobcode/playwright/runner.spec.ts
@@ -123,6 +123,47 @@ test('MobCode Python runner completes blank and comment-only files', async ({ pa
   }
 })
 
+test('MobCode Python runner preserves triple-quoted literal content', async ({ page }) => {
+  const session = await createMobCodeSession(page)
+  await seedMobCodeFile(page, session, [
+    'def show_example():',
+    '    example = """',
+    'def prompt():',
+    '    return input("This is literal text")',
+    '"""',
+    '    return example',
+    'print(show_example())',
+  ].join('\n'))
+  await openMobCodeManager(page, session)
+
+  const popup = await runMobCodePopup(page)
+  const terminal = popup.locator('#terminal')
+
+  await expect(terminal).toContainText('def prompt():', { timeout: 15_000 })
+  await expect(terminal).toContainText('return input("This is literal text")')
+  await expect(terminal).not.toContainText('async def prompt():')
+  await expect(terminal).not.toContainText('await mobcode_input')
+  await expect(popup.getByRole('button', { name: 'Close Python runner' })).toHaveText('Done', { timeout: 15_000 })
+  await clickRunnerDoneAndWaitForClose(popup)
+})
+
+test('MobCode Python runner preserves triple-quoted string indentation', async ({ page }) => {
+  const session = await createMobCodeSession(page)
+  await seedMobCodeFile(page, session, [
+    "s = '''",
+    'hi',
+    "'''",
+    'print(len(s))',
+  ].join('\n'))
+  await openMobCodeManager(page, session)
+
+  const popup = await runMobCodePopup(page)
+
+  await expect(popup.locator('#terminal')).toContainText('4', { timeout: 15_000 })
+  await expect(popup.getByRole('button', { name: 'Close Python runner' })).toHaveText('Done', { timeout: 15_000 })
+  await clickRunnerDoneAndWaitForClose(popup)
+})
+
 test('MobCode Python runner popup imports workspace Python modules', async ({ page }) => {
   const session = await createMobCodeSession(page)
   await seedMobCodeFiles(page, session, {

--- a/activities/mobcode/playwright/runner.spec.ts
+++ b/activities/mobcode/playwright/runner.spec.ts
@@ -109,6 +109,33 @@ test('MobCode Python runner popup prints terminal output', async ({ page }) => {
   await clickRunnerDoneAndWaitForClose(popup)
 })
 
+test('MobCode keeps the workspace header fixed while long source scrolls', async ({ page }) => {
+  const session = await createMobCodeSession(page)
+  await seedMobCodeFile(page, session, Array.from({ length: 500 }, (_, index) => `print(${index})`).join('\n'))
+  await openMobCodeManager(page, session)
+
+  const editorScroller = page.locator('.mobcode-editor-pane .cm-scroller')
+  await expect(editorScroller).toBeVisible()
+  const headerTopBeforeScroll = await page.locator('.mobcode-shell h1').evaluate((header) => header.getBoundingClientRect().top)
+
+  await editorScroller.evaluate((scroller) => {
+    scroller.scrollTop = scroller.scrollHeight
+  })
+
+  const layout = await editorScroller.evaluate((scroller) => ({
+    editorScrollTop: scroller.scrollTop,
+    editorScrollHeight: scroller.scrollHeight,
+    editorClientHeight: scroller.clientHeight,
+    documentScrollTop: document.scrollingElement?.scrollTop ?? 0,
+  }))
+  const headerTopAfterScroll = await page.locator('.mobcode-shell h1').evaluate((header) => header.getBoundingClientRect().top)
+
+  expect(layout.editorScrollHeight).toBeGreaterThan(layout.editorClientHeight)
+  expect(layout.editorScrollTop).toBeGreaterThan(0)
+  expect(layout.documentScrollTop).toBe(0)
+  expect(headerTopAfterScroll).toBe(headerTopBeforeScroll)
+})
+
 test('MobCode Python runner completes blank and comment-only files', async ({ page }) => {
   for (const source of ['', '# Nothing to run yet\n']) {
     const session = await createMobCodeSession(page)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed handling of multiline Python string literals in the MobCode runner.
  - Preserved literal text, `input()` content, and indentation during execution.

- **Style**
  - Improved workspace layout with fixed headers, viewport-aware sizing, editor scrolling, and sidebar scrolling.
  - Maintained responsive behavior on mobile devices.

- **Tests**
  - Added automated coverage for multiline literals, runner output, scrolling, and workspace layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->