### PR TITLE
Give the Postboard manager prompt more room and fix empty-board layout

### DIFF
--- a/activities/postboard/client/manager/PostboardManager.promptBar.test.tsx
+++ b/activities/postboard/client/manager/PostboardManager.promptBar.test.tsx
@@ -1,0 +1,205 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import * as React from 'react'
+import { JSDOM } from 'jsdom'
+import type { PostboardInstructorSnapshot } from '../../shared/types.js'
+
+;(globalThis as { React?: typeof React }).React = React
+
+type TestingLibraryAct = (callback: () => void | Promise<void>) => void | Promise<void>
+
+function installDomEnvironment(url: string) {
+  const dom = new JSDOM('<!doctype html><html><body></body></html>', { url })
+
+  const previousWindow = globalThis.window
+  const previousDocument = globalThis.document
+  const previousNavigatorDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'navigator')
+  const previousHTMLElement = globalThis.HTMLElement
+  const previousNode = globalThis.Node
+
+  ;(globalThis as { window?: Window & typeof globalThis }).window = dom.window as unknown as Window & typeof globalThis
+  ;(globalThis as { document?: Document }).document = dom.window.document
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    writable: true,
+    value: dom.window.navigator,
+  })
+  globalThis.HTMLElement = dom.window.HTMLElement
+  globalThis.Node = dom.window.Node
+
+  return () => {
+    globalThis.document?.body?.replaceChildren()
+    dom.window.close()
+    ;(globalThis as { window?: Window & typeof globalThis }).window = previousWindow
+    ;(globalThis as { document?: Document }).document = previousDocument
+    globalThis.HTMLElement = previousHTMLElement
+    globalThis.Node = previousNode
+    if (previousNavigatorDescriptor) {
+      Object.defineProperty(globalThis, 'navigator', previousNavigatorDescriptor)
+    } else {
+      delete (globalThis as { navigator?: Navigator }).navigator
+    }
+  }
+}
+
+function buildSnapshot(promptText: string): PostboardInstructorSnapshot {
+  return {
+    prompt: { id: 'prompt-1', text: promptText, createdAt: 0, updatedAt: 0 },
+    settings: { autoApprove: false },
+    posts: [],
+    reactionCounts: {},
+    viewerReactions: {},
+    flags: {},
+  }
+}
+
+void test('PostboardManager prompt bar toggle opens and closes the inline editor with correct aria state', { concurrency: false }, async () => {
+  const restoreDom = installDomEnvironment('https://bits.example/manage/postboard/session-1')
+  const previousFetch = globalThis.fetch
+  const snapshot = buildSnapshot('')
+
+  globalThis.fetch = (async (input) => {
+    const url = String(input)
+    if (url.endsWith('/instructor-state')) {
+      return new Response(JSON.stringify(snapshot), { status: 200 })
+    }
+    throw new Error(`Unexpected fetch: ${url}`)
+  }) as typeof fetch
+
+  let cleanup: (() => void) | null = null
+  let unmount: (() => void) | null = null
+  let act: TestingLibraryAct | null = null
+
+  try {
+    const testingLibrary = await import('@testing-library/react')
+    const { fireEvent, render, waitFor } = testingLibrary
+    cleanup = testingLibrary.cleanup
+    act = testingLibrary.act
+    const { MemoryRouter, Route, Routes } = await import('react-router')
+    const { default: PostboardManager } = await import('./PostboardManager.js')
+
+    const rendered = render(
+      <MemoryRouter initialEntries={[{ pathname: '/manage/postboard/session-1', state: { instructorPasscode: 'pw-1' } }]}>
+        <Routes>
+          <Route path="/manage/postboard/:sessionId" element={<PostboardManager />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+    unmount = rendered.unmount
+
+    // No prompt is set yet, so the editor should open automatically.
+    await waitFor(() => {
+      assert.notEqual(rendered.container.querySelector('#postboard-setup-form'), null)
+    })
+
+    const toggleButton = rendered.getByRole('button', { name: /close prompt editor/i })
+    assert.equal(toggleButton.getAttribute('aria-expanded'), 'true')
+
+    fireEvent.click(toggleButton)
+
+    await waitFor(() => {
+      assert.equal(rendered.container.querySelector('#postboard-setup-form'), null)
+    })
+    const reopenButton = rendered.getByRole('button', { name: /edit prompt/i })
+    assert.equal(reopenButton.getAttribute('aria-expanded'), 'false')
+    assert.ok(rendered.container.textContent?.includes('No prompt set'))
+
+    fireEvent.click(reopenButton)
+
+    await waitFor(() => {
+      assert.notEqual(rendered.container.querySelector('#postboard-setup-form'), null)
+    })
+    assert.equal(rendered.getByRole('button', { name: /close prompt editor/i }).getAttribute('aria-expanded'), 'true')
+  } finally {
+    if (act) {
+      await act(async () => {
+        unmount?.()
+        cleanup?.()
+        await Promise.resolve()
+      })
+    } else {
+      unmount?.()
+      cleanup?.()
+    }
+    globalThis.fetch = previousFetch
+    restoreDom()
+  }
+})
+
+void test('PostboardManager saves the prompt and renders the saved text in the prompt bar', { concurrency: false }, async () => {
+  const restoreDom = installDomEnvironment('https://bits.example/manage/postboard/session-1')
+  const previousFetch = globalThis.fetch
+  let snapshot = buildSnapshot('')
+  const setupPosts: Array<{ url: string, body: unknown }> = []
+
+  globalThis.fetch = (async (input, init) => {
+    const url = String(input)
+    if (url.endsWith('/instructor-state')) {
+      return new Response(JSON.stringify(snapshot), { status: 200 })
+    }
+    if (url.endsWith('/setup')) {
+      const body = typeof init?.body === 'string' ? JSON.parse(init.body) as { prompt: string, autoApprove: boolean } : null
+      setupPosts.push({ url, body })
+      snapshot = buildSnapshot(body?.prompt ?? '')
+      return new Response(JSON.stringify(snapshot), { status: 200 })
+    }
+    throw new Error(`Unexpected fetch: ${url}`)
+  }) as typeof fetch
+
+  let cleanup: (() => void) | null = null
+  let unmount: (() => void) | null = null
+  let act: TestingLibraryAct | null = null
+
+  try {
+    const testingLibrary = await import('@testing-library/react')
+    const { fireEvent, render, waitFor } = testingLibrary
+    cleanup = testingLibrary.cleanup
+    act = testingLibrary.act
+    const { MemoryRouter, Route, Routes } = await import('react-router')
+    const { default: PostboardManager } = await import('./PostboardManager.js')
+
+    const rendered = render(
+      <MemoryRouter initialEntries={[{ pathname: '/manage/postboard/session-1', state: { instructorPasscode: 'pw-1' } }]}>
+        <Routes>
+          <Route path="/manage/postboard/:sessionId" element={<PostboardManager />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+    unmount = rendered.unmount
+
+    await waitFor(() => {
+      assert.notEqual(rendered.container.querySelector('#postboard-setup-form'), null)
+    })
+
+    const textarea = rendered.container.querySelector('#postboard-setup-form textarea')
+    assert.notEqual(textarea, null)
+    fireEvent.change(textarea as HTMLTextAreaElement, { target: { value: 'What did you learn today?' } })
+    fireEvent.click(rendered.getByRole('button', { name: /save prompt/i }))
+
+    await waitFor(() => {
+      assert.equal(setupPosts.length, 1)
+    })
+    assert.deepEqual(setupPosts[0]?.body, { prompt: 'What did you learn today?', autoApprove: false })
+
+    // A non-empty prompt closes the editor and the saved text renders in the bar.
+    await waitFor(() => {
+      assert.equal(rendered.container.querySelector('#postboard-setup-form'), null)
+    })
+    await waitFor(() => {
+      assert.ok(rendered.container.querySelector('.postboard-prompt-bar-text')?.textContent?.includes('What did you learn today?'))
+    })
+  } finally {
+    if (act) {
+      await act(async () => {
+        unmount?.()
+        cleanup?.()
+        await Promise.resolve()
+      })
+    } else {
+      unmount?.()
+      cleanup?.()
+    }
+    globalThis.fetch = previousFetch
+    restoreDom()
+  }
+})

--- a/activities/postboard/client/manager/PostboardManager.tsx
+++ b/activities/postboard/client/manager/PostboardManager.tsx
@@ -372,11 +372,34 @@ export default function PostboardManager(): React.JSX.Element {
       <SessionHeader
         activityName="Postboard"
         sessionId={sessionId}
-        centerHeaderActions={(
-          <div className="postboard-header-setup">
-            <span className="postboard-header-prompt" title={snapshot?.prompt.text || 'No prompt set'}>
-              {snapshot?.prompt.text || 'No prompt set'}
-            </span>
+      />
+
+      {error && <div className="postboard-alert" role="alert">{error}</div>}
+
+      <div className="postboard-layout">
+        <div className="postboard-main">
+          <div className="postboard-prompt-bar">
+            {isSetupOpen ? (
+              <form id="postboard-setup-form" className="postboard-prompt-bar-form" onSubmit={handleSetupSubmit}>
+                <label className="postboard-prompt-bar-field">
+                  <span className="postboard-sr-only">Prompt text</span>
+                  <textarea
+                    value={promptDraft}
+                    onChange={(event) => setPromptDraft(event.target.value)}
+                    rows={2}
+                    maxLength={1000}
+                    autoFocus
+                  />
+                </label>
+                <Button type="submit" disabled={isSavingSetup} aria-disabled={isSavingSetup}>
+                  {isSavingSetup ? 'Saving...' : 'Save prompt'}
+                </Button>
+              </form>
+            ) : (
+              <span className="postboard-prompt-bar-text" title={snapshot?.prompt.text || 'No prompt set'}>
+                {snapshot?.prompt.text || 'No prompt set'}
+              </span>
+            )}
             <button
               type="button"
               className="postboard-header-icon-button"
@@ -386,7 +409,7 @@ export default function PostboardManager(): React.JSX.Element {
               aria-label={isSetupOpen ? 'Close prompt editor' : 'Edit prompt'}
               title={isSetupOpen ? 'Close prompt editor' : 'Edit prompt'}
             >
-              ✏️
+              {isSetupOpen ? '✕' : '✏️'}
             </button>
             <button
               type="button"
@@ -404,31 +427,6 @@ export default function PostboardManager(): React.JSX.Element {
               </span>
             </button>
           </div>
-        )}
-      />
-
-      {error && <div className="postboard-alert" role="alert">{error}</div>}
-
-      <div className="postboard-layout">
-        <div className="postboard-main">
-          {isSetupOpen && (
-            <section className="postboard-panel" aria-label="Edit prompt">
-              <form id="postboard-setup-form" className="postboard-form" onSubmit={handleSetupSubmit}>
-                <label>
-                  <span>Prompt text</span>
-                  <textarea
-                    value={promptDraft}
-                    onChange={(event) => setPromptDraft(event.target.value)}
-                    rows={3}
-                    maxLength={1000}
-                  />
-                </label>
-                <Button type="submit" disabled={isSavingSetup} aria-disabled={isSavingSetup}>
-                  {isSavingSetup ? 'Saving...' : 'Save prompt'}
-                </Button>
-              </form>
-            </section>
-          )}
 
           <section className="postboard-panel" aria-labelledby="postboard-all-posts-title">
             <h2 id="postboard-all-posts-title">Board Posts ({boardPosts.length})</h2>

--- a/activities/postboard/client/styles.css
+++ b/activities/postboard/client/styles.css
@@ -27,6 +27,7 @@
 .postboard-main {
   flex: 1 1 auto;
   min-width: 0;
+  align-self: flex-start;
 }
 
 .postboard-sticky-side {
@@ -150,20 +151,60 @@
   margin-left: auto;
 }
 
-.postboard-header-setup {
+.postboard-prompt-bar {
+  position: sticky;
+  top: 0;
+  z-index: 30;
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 0.4rem;
-  max-width: min(28rem, 40vw);
+  gap: 0.6rem;
+  margin-bottom: 1rem;
+  border: 1px solid #d8e2ea;
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 0.6rem 0.9rem;
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
 }
 
-.postboard-header-prompt {
-  overflow: hidden;
+.postboard-prompt-bar-text {
+  overflow-wrap: anywhere;
+  flex: 1 1 auto;
+  min-width: 0;
   color: #334155;
-  font-size: 0.9rem;
+  font-size: 0.95rem;
   font-weight: 600;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+}
+
+.postboard-prompt-bar-form {
+  display: flex;
+  flex: 1 1 auto;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 0.6rem;
+  min-width: 0;
+}
+
+.postboard-prompt-bar-field {
+  flex: 1 1 16rem;
+  min-width: 0;
+}
+
+.postboard-prompt-bar-field textarea {
+  width: 100%;
+  resize: vertical;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 0.5rem 0.65rem;
+  color: #111827;
+  font: inherit;
+}
+
+.postboard-prompt-bar-field textarea:focus {
+  border-color: #0f766e;
+  box-shadow: 0 0 0 2px rgba(15, 118, 110, 0.14);
+  outline: none;
 }
 
 .postboard-header-icon-button {

--- a/activities/postboard/playwright/layout.spec.ts
+++ b/activities/postboard/playwright/layout.spec.ts
@@ -1,0 +1,44 @@
+import { expect, type Page, test } from '@playwright/test'
+
+interface PostboardCreateResponse {
+  id: string
+  instructorPasscode: string
+}
+
+async function createPostboardSession(page: Page): Promise<PostboardCreateResponse> {
+  const response = await page.request.post('/api/postboard/create')
+  expect(response.ok()).toBe(true)
+  return await response.json() as PostboardCreateResponse
+}
+
+async function openPostboardManager(page: Page, session: PostboardCreateResponse): Promise<void> {
+  await page.addInitScript(({ instructorPasscode }) => {
+    window.history.replaceState(
+      {
+        usr: { createSessionPayload: { instructorPasscode } },
+        key: 'postboard-layout-playwright',
+        idx: 0,
+      },
+      '',
+      window.location.href,
+    )
+  }, { instructorPasscode: session.instructorPasscode })
+  await page.goto(`/manage/postboard/${encodeURIComponent(session.id)}`)
+  await expect(page.getByRole('heading', { name: /Board Posts/ })).toBeVisible()
+}
+
+test('empty board keeps the prompt bar and board panel aligned with the top of the moderation sidebar', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 900 })
+  const session = await createPostboardSession(page)
+  await openPostboardManager(page, session)
+
+  // With no posts, the moderation queue + compose sidebar is taller than the
+  // prompt bar/board panel column. They must still start at the same top
+  // edge instead of the shorter column being pushed down to bottom-align
+  // with the taller sidebar (regression: align-items: flex-end on the row).
+  const promptBarBox = await page.locator('.postboard-prompt-bar').boundingBox()
+  const sidebarBox = await page.locator('.postboard-sticky-side').boundingBox()
+  expect(promptBarBox).not.toBeNull()
+  expect(sidebarBox).not.toBeNull()
+  expect(Math.abs((promptBarBox?.y ?? 0) - (sidebarBox?.y ?? 0))).toBeLessThanOrEqual(1)
+})


### PR DESCRIPTION
Move the prompt out of the constrained SessionHeader center slot into a floating bar scoped to the main column (left of the moderation queue), with the edit form merged inline instead of a separate toggled panel.

Also fix .postboard-main getting pushed down by the layout's align-items: flex-end whenever the moderation/compose sidebar was taller (most visibly with zero posts), by pinning the main column to the top while preserving the sidebar's sticky-to-bottom behavior for long boards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Moved prompt details and editing controls from the session header into a dedicated prompt bar above the board.
  * Added a compact, responsive prompt editor with improved layout and focus styling.
  * Kept prompt editing accessible from the header with updated edit and close controls.
  * Improved prompt visibility and positioning with a sticky prompt bar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->