### PR TITLE
mobcode defaults to broacast instructor changes

### DIFF
--- a/.agent/knowledge/data-contracts.md
+++ b/.agent/knowledge/data-contracts.md
@@ -1,4 +1,6 @@
-### MobCode live-session defaults
+# Data Contracts
+
+## MobCode live-session defaults
 
 - Date: 2026-08-19
 - Area: activities | mobcode | session normalization
@@ -6,8 +8,6 @@
 - Why it matters: Standalone and embedded sessions should immediately mirror instructor edits by default without overwriting later instructor toggle choices during normalization or reload.
 - Evidence: `activities/mobcode/server/routes.ts`; `activities/mobcode/server/routes.test.ts`; `skills/syncdeck/references/ACTIVITY_PAYLOADS.md`
 - Owner: Codex
-
-# Data Contracts
 
 Document API and data-shape assumptions that must stay compatible over time.
 

--- a/.agent/knowledge/data-contracts.md
+++ b/.agent/knowledge/data-contracts.md
@@ -1,3 +1,12 @@
+### MobCode live-session defaults
+
+- Date: 2026-08-19
+- Area: activities | mobcode | session normalization
+- Contract: Newly initialized MobCode live sessions set `studentCode.shareChangesEnabled` to `true` unless `embeddedLaunch.selectedOptions.startTryItMode === true`. Once `studentCode` exists, persisted instructor flags remain authoritative.
+- Why it matters: Standalone and embedded sessions should immediately mirror instructor edits by default without overwriting later instructor toggle choices during normalization or reload.
+- Evidence: `activities/mobcode/server/routes.ts`; `activities/mobcode/server/routes.test.ts`; `skills/syncdeck/references/ACTIVITY_PAYLOADS.md`
+- Owner: Codex
+
 # Data Contracts
 
 Document API and data-shape assumptions that must stay compatible over time.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -83,7 +83,7 @@ session.
 5. Student is shown the appropriate activity component
 6. Student interacts with the activity
 
-For live MobCode sessions, the instructor workspace remains `groups.default`. When the instructor enables Try it, MobCode creates one private, server-backed workspace per accepted waiting-room participant from an explicit starter snapshot. The instructor controls whether their code is broadcast live or students keep the last published version. Student responses are participant-scoped and never include peer names or files; instructors may inspect named workspaces and publish one anonymous shared copy that they can edit and broadcast to the class in real time.
+For live MobCode sessions, the instructor workspace remains `groups.default`. Newly initialized sessions broadcast instructor changes by default unless they begin with Try it enabled. When the instructor enables Try it, MobCode creates one private, server-backed workspace per accepted waiting-room participant from an explicit starter snapshot. The instructor controls whether their code is broadcast live or students keep the last published version. Student responses are participant-scoped and never include peer names or files; instructors may inspect named workspaces and publish one anonymous shared copy that they can edit and broadcast to the class in real time.
 
 ### Session Lifecycle
 - **Temporary sessions**: Created on-demand, expire after inactivity

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Current activity areas include:
 - Live response collection and class discussion activities
 - Java and Python practice activities
 - Standalone practice and utility flows for independent student work
-- MobCode live sessions, including instructor-controlled private student code workspaces
+- MobCode live sessions, including instructor-controlled private student code workspaces; newly initialized live sessions broadcast instructor changes by default unless they begin in Try it mode
 
 SyncDeck can embed supported activities inside a presentation; embedded instructor views are launched through the active SyncDeck session and do not require teachers to repeat child-activity setup. Activities with manager credentials receive them through a short-lived handoff; credentialless activities such as Raffle launch directly. The initiating manager applies the authenticated launch response locally, so first-load embedded activities do not wait for a websocket replay before mounting, and it performs a bounded refresh for an expired or consumed child bootstrap.
 SyncDeck also preserves a temporary-session instructor's control after a reload with a bounded, browser-session httpOnly recovery cookie; instructor passcodes are never stored in browser storage.

--- a/activities/mobcode/server/routes.test.ts
+++ b/activities/mobcode/server/routes.test.ts
@@ -159,8 +159,31 @@ void test('normalizeMobCodeSessionData enables embedded Try it with an initial i
     embeddedLaunch: { selectedOptions: { files: { 'main.py': 'print(1)' }, activeFile: 'main.py', startTryItMode: true } },
   })
   assert.equal(data.studentCode?.tryItEnabled, true)
+  assert.equal(data.studentCode?.shareChangesEnabled, false)
   assert.deepEqual(data.studentCode?.starterVersion, data.groups.default)
   assert.notEqual(data.studentCode?.starterVersion, data.groups.default)
+})
+
+void test('normalizeMobCodeSessionData broadcasts instructor changes by default', () => {
+  const data = normalizeMobCodeSessionData({})
+
+  assert.equal(data.studentCode?.tryItEnabled, false)
+  assert.equal(data.studentCode?.shareChangesEnabled, true)
+})
+
+void test('normalizeMobCodeSessionData preserves an instructor choice to stop broadcasting', () => {
+  const data = normalizeMobCodeSessionData({
+    studentCode: {
+      tryItEnabled: false,
+      shareChangesEnabled: false,
+      publishedInstructorVersion: { files: {}, activeFile: '' },
+      starterVersion: null,
+      studentWorkspaces: {},
+      sharedExample: null,
+    },
+  })
+
+  assert.equal(data.studentCode?.shareChangesEnabled, false)
 })
 
 void test('normalizeMobCodeSessionData drops reserved participant keys and uses a prototype-free workspace map', () => {

--- a/activities/mobcode/server/routes.ts
+++ b/activities/mobcode/server/routes.ts
@@ -191,6 +191,7 @@ function normalizeStudentCodeState(value: unknown, defaultGroup: MobCodeGroupSta
   const startTryItMode = selectedOptions?.startTryItMode === true
   const tryItEnabled = raw.tryItEnabled === true || (startTryItMode && !isPlainObject(value))
   const shareChangesEnabled = raw.shareChangesEnabled === true
+    || (!startTryItMode && !isPlainObject(value))
   const publishedInstructorVersion = isPlainObject(raw.publishedInstructorVersion)
     ? normalizeGroupState(raw.publishedInstructorVersion)
     : cloneGroupState(defaultGroup)

--- a/skills/syncdeck/references/ACTIVITY_PAYLOADS.md
+++ b/skills/syncdeck/references/ACTIVITY_PAYLOADS.md
@@ -309,6 +309,7 @@ Field guidance:
 - `activeFile` is optional and should match one of the `files` keys when provided
 - `runnerId` is optional; use `brython-terminal` to preselect the Python popup runner for Python-focused launches
 - `startTryItMode` is optional and boolean-only. For a live embedded session, `true` enables students' private `My code` workspaces and publishes the initial instructor files as their reset baseline. It does not affect solo launches.
+- MobCode live sessions broadcast instructor changes by default. Setting `startTryItMode` to `true` starts the embedded child in Try it mode with instructor broadcasting disabled.
 - paths are normalized as safe relative virtual paths such as `src/Main.java`; traversal segments such as `../`, empty paths, oversized paths, and reserved JavaScript object segments such as `__proto__`, `constructor`, or `prototype` are rejected and will not load
 - MobCode currently keeps up to 250 starter files, truncates individual file content at 1 MB, and stops accepting starter content once the total workspace seed reaches 4 MiB
 - omit `files` to start with an empty MobCode workspace


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Newly created MobCode live sessions now share instructor changes by default.
  * Sessions launched in Try It mode keep instructor change sharing disabled.
  * Existing instructor settings, including explicitly disabled sharing, remain preserved when sessions are reloaded.

* **Documentation**
  * Updated MobCode architecture, README, and payload guidance to reflect the new live-session defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->