### PR TITLE
chore: bump nanoid to 3.3.18 (GHSA-2v37-7h3g-55p8)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2686,9 +2686,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6295,9 +6295,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.16",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+            "version": "3.3.18",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+            "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
             "funding": [
                 {
                     "type": "github",


### PR DESCRIPTION
## What

Resolves the two Dependabot alerts for **`nanoid` < 3.3.18** ([GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) — "custom generators can loop indefinitely when size is zero", severity high), one per lockfile:

- `package-lock.json`: `nanoid` 3.3.16 → 3.3.18
- `client/package-lock.json`: `nanoid` 3.3.16 → 3.3.18

## Why it's low-risk

`nanoid` is a transitive, build-time-only dependency: `vite@8.1.0 → postcss@8.5.23 → nanoid`. `postcss` declares `nanoid@^3.3.16`, which the patched `3.3.18` satisfies, so this is **lockfile-only** — no `package.json` changes, no direct dependency added.

## Verification

- `npm test` passes (unit + typecheck + lint across all workspaces; server smoke test OK).
- `npm audit` no longer reports `nanoid` in either workspace.

## Out of scope

`npm audit` also reports a separate high-severity advisory for **`brace-expansion`** (`5.0.7`, via `eslint@10.5.0 → minimatch → brace-expansion`, GHSA-mh99-v99m-4gvg / GHSA-rgw5-rvv9-x895). Dependabot's alert list did not include it. Left for a separate follow-up to keep this PR focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)