### PR TITLE
chore: bump brace-expansion to 5.0.9 (GHSA-mh99-v99m-4gvg)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1637,16 +1637,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3169,16 +3169,16 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.7",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": "20 || >=22"
             }
         },
         "node_modules/braces": {


### PR DESCRIPTION
## What

Clears the high-severity `brace-expansion` advisory reported by `npm audit`:

- [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) — DoS via unbounded expansion length (OOM crash)
- [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) — DoS via unbounded intermediate arrays

`brace-expansion` 5.0.7 → 5.0.9 in `package-lock.json` and `client/package-lock.json`.

## Why it's low-risk

Transitive **dev-only** dependency: `eslint@10.5.0 → minimatch@10.2.5 → brace-expansion`. `minimatch` requires `brace-expansion@^5.0.5`, which the patched `5.0.9` satisfies — **lockfile-only**, no `package.json` changes.

## Verification

- `npm test` passes (unit + typecheck + lint across all workspaces; server smoke test OK).
- `npm audit` no longer reports `brace-expansion`.

## Related

Companion to #347 (nanoid). Both branch from `main` and are independent; once both merge, `npm audit` on `main` is clean. This branch still shows the nanoid alert until #347 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)